### PR TITLE
add png favicons for better resolution and android compatibility

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,8 @@
   {% endif %}
 
   <link rel="shortcut icon" href="{{ "favicon.ico" | absolute_url }}" type="image/x-icon">
+  <link rel="icon" type="image/png" href="{{ "favicon.png" | absolute_url }}" sizes="32x32">
+  <link rel="icon" type="image/png" href="{{ "favicon.png" | absolute_url }}" sizes="96x96">
 
   <link rel="stylesheet" href="{{ "/assets/css/just-the-docs.css" | absolute_url }}">
 


### PR DESCRIPTION
I added two favicon links, one for a png favicon, an another for the android one.