### PR TITLE
Feature: Nav - support sidebar_label to override title in navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
             {% if page.parent == node.title or page.grand_parent == node.title %}
               {% assign first_level_url = node.url | absolute_url %}
             {% endif %}
-            <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+            <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.sidebar_label || node.title }}</a>
             {% if node.has_children %}
               {% assign children_list = site.html_pages | sort:"nav_order" %}
               <ul class="navigation-list-child-list ">
@@ -18,14 +18,14 @@
                       {% if page.url == child.url or page.parent == child.title %}
                         {% assign second_level_url = child.url | absolute_url %}
                       {% endif %}
-                      <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+                      <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.sidebar_label || child.title }}</a>
                       {% if child.has_children %}
                         {% assign grand_children_list = site.html_pages | sort:"nav_order" %}
                         <ul class="navigation-list-child-list">
                           {% for grand_child in grand_children_list %}
                             {% if grand_child.parent == child.title %}
                               <li class="navigation-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                                <a href="{{ grand_child.url | absolute_url }}" class="navigation-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                                <a href="{{ grand_child.url | absolute_url }}" class="navigation-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.sidebar_label || grand_child.title }}</a>
                               </li>
                             {% endif %}
                           {% endfor %}


### PR DESCRIPTION
Hey!

Title is used for SEO and sometimes title in sidebar can be different:

Example

```
---
layout: home
title: Social Sign PHP Library
sidebar_label: Home
nav_order: 1
---
```

Thanks