### PR TITLE
Enable IP anonymization in Google Analytics (GDPR)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,7 +47,7 @@ color_scheme: nil
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
 ga_tracking: UA-2709176-10
-ga_tracking_anonymize_ip: true
+ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true by default)
 
 plugins:
   - jekyll-seo-tag

--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,7 @@ color_scheme: nil
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
 ga_tracking: UA-2709176-10
+ga_tracking_anonymize_ip: true
 
 plugins:
   - jekyll-seo-tag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', '{{ site.ga_tracking }}'{% if site.ga_tracking_anonymize_ip %}, { 'anonymize_ip': true }{% endif %});
+      gtag('config', '{{ site.ga_tracking }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
     </script>
 
   {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', "{{ site.ga_tracking }}");
+      gtag('config', '{{ site.ga_tracking }}'{% if site.ga_tracking_anonymize_ip %}, { 'anonymize_ip': true }{% endif %});
     </script>
 
   {% endif %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,5 +85,5 @@ See [Customization]({{ site.baseurl }}{% link docs/customization.md %}) for more
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
 ga_tracking: UA-5555555-55
-ga_tracking_anonymize_ip: true
+ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true by default)
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,4 +85,5 @@ See [Customization]({{ site.baseurl }}{% link docs/customization.md %}) for more
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
 ga_tracking: UA-5555555-55
+ga_tracking_anonymize_ip: true
 ```


### PR DESCRIPTION
Thank for this very useful theme!
We started enrollment of this theme for _NetLicensing Wiki_ documentation and made some changes which might be useful for the community.
Please find this PR for:
- introduce GDPR compliant Google Analytics settings `ga_tracking_anonymize_ip`