### PR TITLE
Create next_prev.html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
 gemspec
+gem "kramdown-parser-gfm"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source "https://rubygems.org"
 gemspec
-gem "kramdown-parser-gfm"

--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,7 @@ nav_sort: case_insensitive # default, equivalent to nil
 # nav_sort: case_sensitive # Capital letters sorted before lowercase
 
 # Display next and previous links
-nav_next_prev: true
+nav_next_prev: false
 
 # Footer content
 # appears at the bottom of every page's main content

--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,9 @@ aux_links_new_tab: false
 nav_sort: case_insensitive # default, equivalent to nil
 # nav_sort: case_sensitive # Capital letters sorted before lowercase
 
+# Display next and previous links
+nav_next_prev: true
+
 # Footer content
 # appears at the bottom of every page's main content
 

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@
 title: Just the Docs
 description: A Jekyll theme for documentation
 baseurl: "/just-the-docs" # the subpath of your site, e.g. /blog
-url: "https://pmarsceill.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://jeffreycwitt.com" # the base hostname & protocol for your site, e.g. http://example.com
 
 permalink: pretty
 exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "package.json", "package-lock.json",  "script/", "LICENSE.txt", "lib/", "bin/", "README.md", "Rakefile"]

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -9,9 +9,21 @@
     {%- assign sorted_unordered_pages_list = unordered_pages_list | sort:"title" -%}
   {%- endif -%}
   {%- assign pages_list = sorted_ordered_pages_list | concat: sorted_unordered_pages_list -%}
+  {%- assign previous_page = nil -%}
+  {%- assign next_page = nil -%}
+  {%- assign top_level_prev = nil -%}
+  {%- assign top_level_page = nil -%}
   {%- for node in pages_list -%}
     {%- unless node.nav_exclude -%}
       {%- if node.parent == nil and node.title -%}
+        {%- if page.url == node.url -%}
+          {%- assign previous_page = top_level_prev -%}
+          {%- assign top_level_page = page -%}
+        {%- elsif top_level_page != nil and next_page == nil -%}
+          {%- assign next_page = node -%}
+        {%- else -%}
+          {%- assign top_level_prev = node -%}
+        {%- endif -%}
         <li class="nav-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
           {%- if page.parent == node.title or page.grand_parent == node.title -%}
             {%- assign first_level_url = node.url | absolute_url -%}
@@ -23,8 +35,18 @@
           {%- if node.has_children -%}
             {%- assign children_list = pages_list | where: "parent", node.title -%}
             <ul class="nav-list ">
+            {%- assign child_level_prev = nil -%}
+            {%- assign child_level_page = nil -%}
             {%- for child in children_list -%}
               {%- unless child.nav_exclude -%}
+                {%- if page.url == child.url -%}
+                  {%- assign previous_page = child_level_prev -%}
+                  {%- assign child_level_page = page -%}
+                {%- elsif child_level_page != nil and next_page == nil -%}
+                    {%- assign next_page = child -%}
+                {%- else -%}
+                  {%- assign child_level_prev = child -%}
+                {%- endif -%}
                 <li class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
                   {%- if page.url == child.url or page.parent == child.title -%}
                     {%- assign second_level_url = child.url | absolute_url -%}
@@ -36,7 +58,17 @@
                   {%- if child.has_children -%}
                     {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
                     <ul class="nav-list">
+                    {%- assign grand_child_level_prev = nil -%}
+                    {%- assign grand_child_level_page = nil -%}
                     {%- for grand_child in grand_children_list -%}
+                      {%- if page.url == grand_child.url -%}
+                        {%- assign previous_page = grand_child_level_prev -%}
+                        {%- assign grand_child_level_page = page -%}
+                      {%- elsif grand_child_level_page != nil and next_page == nil -%}
+                        {%- assign next_page = grand_child -%}
+                      {%- else -%}
+                        {%- assign grand_child_level_prev = grand_child -%}
+                      {%- endif -%}
                       <li class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
                         <a href="{{ grand_child.url | absolute_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
                       </li>

--- a/_includes/next_prev.html
+++ b/_includes/next_prev.html
@@ -1,0 +1,18 @@
+<div style="display: flex; justify-content: space-between;">
+{%- assign ordered_pages_list = site.html_pages | where_exp:"item", "item.nav_order != nil" -%}
+{%- assign sorted_ordered_pages_list = ordered_pages_list | sort:"nav_order" -%}
+
+
+{%- for node in sorted_ordered_pages_list -%}
+  {%- assign next_page = page.nav_order | plus: 1 -%}
+  {%- assign previous_page = page.nav_order | minus: 1 -%}
+  {%- if previous_page == node.nav_order -%}
+    <a href="{{ node.url | absolute_url }}">previous</a>
+  {%- endif -%}
+  {%- if next_page == node.nav_order -%}
+    <a href="{{ node.url | absolute_url }}">next</a> 
+  {%- endif -%}
+  
+{%- endfor -%}
+
+</div>

--- a/_includes/next_prev.html
+++ b/_includes/next_prev.html
@@ -1,23 +1,14 @@
-{%- assign ordered_pages_list = site.html_pages | where_exp:"item", "item.nav_order != nil" -%}
-{%- assign sorted_ordered_pages_list = ordered_pages_list | sort:"nav_order" -%}
-
 <nav aria-label="Breadcrumb" class="next-prev-nav">
   <ol class="next-prev-nav-list">
-    {%- for node in sorted_ordered_pages_list -%}
-      {%- if node.parent == page.parent} %}
-        {%- assign next_page = page.nav_order | plus: 1 -%}
-        {%- assign previous_page = page.nav_order | minus: 1 -%}
-        {%- if previous_page == node.nav_order -%}
-        <li class="next-prev-nav-list-item">
-          <a href="{{ node.url | absolute_url }}">Previous</a>
-        </li>
-        {%- endif -%}
-        {%- if next_page == node.nav_order -%}
-        <li class="next-prev-nav-list-item">
-          <a href="{{ node.url | absolute_url }}">Next</a> 
-        </li>
-        {%- endif -%}
-      {%- endif -%}
-    {%- endfor -%}
+  {%- if previous_page -%}
+    <li class="next-prev-nav-list-item">
+      <a href="{{ previous_page.url | absolute_url }}">Previous</a>
+    </li>
+  {%- endif -%}
+  {%- if next_page -%}
+    <li class="next-prev-nav-list-item">
+      <a href="{{ next_page.url | absolute_url }}">Next</a> 
+    </li>
+  {%- endif -%}
   </ol>
 </nav>

--- a/_includes/next_prev.html
+++ b/_includes/next_prev.html
@@ -1,18 +1,23 @@
-<div style="display: flex; justify-content: space-between;">
 {%- assign ordered_pages_list = site.html_pages | where_exp:"item", "item.nav_order != nil" -%}
 {%- assign sorted_ordered_pages_list = ordered_pages_list | sort:"nav_order" -%}
 
-
-{%- for node in sorted_ordered_pages_list -%}
-  {%- assign next_page = page.nav_order | plus: 1 -%}
-  {%- assign previous_page = page.nav_order | minus: 1 -%}
-  {%- if previous_page == node.nav_order -%}
-    <a href="{{ node.url | absolute_url }}">previous</a>
-  {%- endif -%}
-  {%- if next_page == node.nav_order -%}
-    <a href="{{ node.url | absolute_url }}">next</a> 
-  {%- endif -%}
-  
-{%- endfor -%}
-
-</div>
+<nav aria-label="Breadcrumb" class="next-prev-nav">
+  <ol class="next-prev-nav-list">
+    {%- for node in sorted_ordered_pages_list -%}
+      {%- if node.parent == page.parent} %}
+        {%- assign next_page = page.nav_order | plus: 1 -%}
+        {%- assign previous_page = page.nav_order | minus: 1 -%}
+        {%- if previous_page == node.nav_order -%}
+        <li class="next-prev-nav-list-item">
+          <a href="{{ node.url | absolute_url }}">Previous</a>
+        </li>
+        {%- endif -%}
+        {%- if next_page == node.nav_order -%}
+        <li class="next-prev-nav-list-item">
+          <a href="{{ node.url | absolute_url }}">Next</a> 
+        </li>
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  </ol>
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -105,7 +105,9 @@ layout: table_wrappers
           </nav>
         {% endif %}
       {% endunless %}
-      {% include next_prev.html %}
+      {% if site.nav_next_prev == true %}
+        {% include next_prev.html %}
+      {% endif %}
         </div>
       
       

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,6 +84,12 @@ layout: table_wrappers
       {% endif %}
     </div>
     <div id="main-content-wrap" class="main-content-wrap">
+      {% if page.parent %} 
+        {% assign flexposition = "space-between" %}
+      {% else %}
+        {% assign flexposition = "flex-end" %}
+      {% endif %}
+    <div style="display: flex; justify-content: {{ flexposition }}">
       {% unless page.url == "/" %}
         {% if page.parent %}
           <nav aria-label="Breadcrumb" class="breadcrumb-nav">
@@ -99,6 +105,11 @@ layout: table_wrappers
           </nav>
         {% endif %}
       {% endunless %}
+      {% include next_prev.html %}
+        </div>
+      
+      
+      
       <div id="main-content" class="main-content" role="main">
         {% if site.heading_anchors != false %}
           {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" %}

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -225,7 +225,6 @@
     color: $grey-dk-000;
     content: "/";
   }
-
   &:last-child {
     &::after {
       content: "";

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -194,3 +194,41 @@
     }
   }
 }
+
+// Next-Prev nav
+
+.next-prev-nav {
+  @include mq(md) {
+    margin-top: -$sp-4;
+    //float: right;
+  }
+}
+
+.next-prev-nav-list {
+  padding-left: 0;
+  margin-bottom: $sp-3;
+  list-style: none;
+}
+
+.next-prev-nav-list-item {
+  display: table-cell;
+  @include fs-2;
+
+  &::before {
+    display: none;
+  }
+
+  &::after {
+    display: inline-block;
+    margin-right: $sp-2;
+    margin-left: $sp-2;
+    color: $grey-dk-000;
+    content: "/";
+  }
+
+  &:last-child {
+    &::after {
+      content: "";
+    }
+  }
+}


### PR DESCRIPTION
I though it might be nice to have a next_prev.html include that could be included at the top and bottom of pages. The next_prev.html include uses the nav_order page property to find the next or previous page in the sequence and then makes these available as links. This could be added as desired to the default layout like so:
```
{% include next_prev.html %}
{{content}}
{% include next_prev.html %}

Here's how it looks on my end.

Notice the subtle "previous" and "next" at the top.

```
![image](https://user-images.githubusercontent.com/1146685/88460685-fc6c4d00-ce6b-11ea-9bdf-e497c54ae4b5.png)
