### PR TITLE
Ignore a root vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 _site
 Gemfile.lock
 node_modules
+/vendor


### PR DESCRIPTION
**Problem**
When I run `bundle install` I install gems in the local repository which creates a `vendor` directory. When I go to commit, there are many untracked files.

**Solution**
Add the root vendor directory to the .gitignore. This doesn't affect vendor directories inside of other folders.
