### PR TITLE
Optional collection name

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,7 +55,7 @@ layout: table_wrappers
           {% assign collection_value = collection_entry[1] %}
           {% assign collection = site[collection_key] %}
           {% if collection_value.nav_exclude != true %}
-            {% if collections_size > 1 %}
+            {% if collections_size > 1 and collection_value.name != null %}
               <div class="nav-category">{{ collection_value.name }}</div>
             {% endif %}
             {% include nav.html pages=collection %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,3 +196,16 @@ just_the_docs:
       name: Tutorials
 ```
 
+You can choose to remove a collection name.
+This creates a category in the navigation with no heading. This is useful if you'd like to add a link at the top of the sidebar above other collections.
+```yaml
+collections:
+  docs:
+    permalink: "/:collection/:path/"
+    output: true
+
+just_the_docs:
+  collections:
+    docs:
+      name: null
+```


### PR DESCRIPTION
**Rationale**
I'd like to add a link to my homepage that sits above all other collections. If I use collections, all other pages are ignored and not placed in the navigation.

**Solution**
Create a collection that contains just my homepage. Set `name: null` in the collections configuration. With this commit, the collection heading is no longer output and I'm left with just a link to home, followed by all other collections

![collection-name](https://user-images.githubusercontent.com/1830690/98454648-411eaa00-2124-11eb-8655-444995ba22ad.png)
