### PR TITLE
Fix TOC/breadcrumbs for multiple collections

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,23 @@ exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "pac
 # To include them, comment-out the relevant line above.
 # Uncommenting the following line doesn't work - see https://github.com/jekyll/jekyll/issues/4791
 # include: ["docs/tests/"]
+# Uncommenting the following collections configuration produces further tests
+# (it also suppresses all the other pages - see https://github.com/pmarsceill/just-the-docs/issues/447)
+#
+# collections:
+#   test_collection_1:
+#     permalink: "/:collection/:path/"
+#     output: true
+#   test_collection_2:
+#     permalink: "/:collection/:path/"
+#     output: true
+# 
+# just_the_docs:
+#   collections:
+#     test_collection_1:
+#       name: Test Collection 1
+#     test_collection_2:
+#       name: Test Collection 2
 
 # Set a path/url to a logo that will be displayed instead of the title
 #logo: "/assets/images/just-the-docs.png"

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -60,7 +60,7 @@
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
       {%- unless node.nav_exclude -%}
-      <li class="nav-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+      <li class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
         {%- if node.has_children -%}
           <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
         {%- endif -%}
@@ -97,3 +97,29 @@
     {%- endif -%}
   {%- endfor -%}
 </ul>
+
+{%- if page.collection == include.key -%}
+
+  {%- for node in pages_list -%}
+    {%- if node.parent == nil -%}
+      {%- if page.parent == node.title or page.grand_parent == node.title -%}
+        {%- assign first_level_url = node.url | absolute_url -%}
+      {%- endif -%}
+      {%- if node.has_children -%}
+        {%- assign children_list = pages_list | where: "parent", node.title -%}
+        {%- for child in children_list -%}
+          {%- if child.has_children -%}
+            {%- if page.url == child.url or page.parent == child.title and page.grand_parent == child.parent -%}
+              {%- assign second_level_url = child.url | absolute_url -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {% if page.has_children == true and page.has_toc != false %}
+    {%- assign toc_list = pages_list | where: "parent", page.title | where: "grand_parent", page.parent -%}
+  {%- endif -%}
+
+{%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,11 +58,11 @@ layout: table_wrappers
             {% if collections_size > 1 %}
               <div class="nav-category">{{ collection_value.name }}</div>
             {% endif %}
-            {% include nav.html pages=collection %}
+            {% include nav.html pages=collection key=collection_key %}
           {% endif %}
         {% endfor %}
       {% else %}
-        {% include nav.html pages=site.html_pages %}
+        {% include nav.html pages=site.html_pages key=nil %}
       {% endif %}
     </nav>
     <footer class="site-footer">
@@ -102,21 +102,6 @@ layout: table_wrappers
     <div id="main-content-wrap" class="main-content-wrap">
       {% unless page.url == "/" %}
         {% if page.parent %}
-          {%- for node in pages_list -%}
-            {%- if node.parent == nil -%}
-              {%- if page.parent == node.title or page.grand_parent == node.title -%}
-                {%- assign first_level_url = node.url | absolute_url -%}
-              {%- endif -%}
-              {%- if node.has_children -%}
-                {%- assign children_list = pages_list | where: "parent", node.title -%}
-                {%- for child in children_list -%}
-                  {%- if page.url == child.url or page.parent == child.title -%}
-                    {%- assign second_level_url = child.url | absolute_url -%}
-                  {%- endif -%}
-                {%- endfor -%}
-              {%- endif -%}
-            {%- endif -%}
-          {%- endfor -%}
           <nav aria-label="Breadcrumb" class="breadcrumb-nav">
             <ol class="breadcrumb-nav-list">
               {% if page.grand_parent %}
@@ -141,8 +126,7 @@ layout: table_wrappers
           <hr>
           <h2 class="text-delta">Table of contents</h2>
           <ul>
-            {%- assign children_list = pages_list | where: "parent", page.title | where: "grand_parent", page.parent -%}
-            {% for child in children_list %}
+            {% for child in toc_list %}
               <li>
                 <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>{% if child.summary %} - {{ child.summary }}{% endif %}
               </li>

--- a/_test_collection_1/child.md
+++ b/_test_collection_1/child.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Child Test
+parent: Parent Test
+---
+
+# Child Test
+
+This is a child page in Test Collection 1.
+
+The breadcrumb link above should lead to a page in the same collection.

--- a/_test_collection_1/index.md
+++ b/_test_collection_1/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Parent Test
+has_children: true
+---
+
+# Parent Test
+
+This is a top-level page in Test Collection 1.
+
+The link below should lead to a page in the same collection.

--- a/_test_collection_2/child.md
+++ b/_test_collection_2/child.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Child Test
+parent: Parent Test
+---
+
+# Child Test
+
+This is a child page in Test Collection 2.
+
+The breadcrumb link above should lead to a page in the same collection.

--- a/_test_collection_2/index.md
+++ b/_test_collection_2/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Parent Test
+has_children: true
+---
+
+# Parent Test
+
+This is a top-level page in Test Collection 2.
+
+The link below should lead to a page in the same collection.


### PR DESCRIPTION
When configured for more than one collection, v0.3.2 produces empty TOCs of children in all but the last collection, due to referencing the overwritten `pages_list` in `_layouts/default.html`. When the same parent title is used in different collections, v0.3.2 can also produce a link to the wrong collection. Moreover, v0.3.3  can also produce incorrect breadcrumb links; see issue #492.

This PR makes the following changes:

- Move the breadcrumbs link variable assignments from `_layouts/default.html` to `_includes/nav.html`, and make it conditional on `page` being in the current collection.

- Correct the condition for assignment to `second_level_url`, as in #477.

- Change the variable used for the TOC from `children_list` to `toc_list`, move its assignment from `_layouts/default.html` to `_includes/nav.html`, and make it conditional on `page` being in the current collection.

- Add regression tests for TOC/breadcrumb links in multiple collections, with configuration commented-out.

With the v0.3.3 regression tests active, `diff -r -q` on `_site/docs` reports that only `_site/docs/tests/navigation/disambiguation/dca/index.html` differs, which is due to the breadcrumb correction there.

Fixes #492. 