### PR TITLE
Fix nested lists

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -59,7 +59,7 @@
       ol {
         counter-reset: sub-counter;
 
-        li {
+        > li {
           &::before {
             content: counter(sub-counter, lower-alpha);
             counter-increment: sub-counter;

--- a/docs/tests/styling/nested.md
+++ b/docs/tests/styling/nested.md
@@ -23,9 +23,9 @@ grand_parent: Tests
 
 ----
 
-1. Ordered List 1
-    1. Ordered List 2
-        1. Ordered List 3
-            1. Ordered List 4
-                1. Ordered List 5
-                    1. Ordered List 6
+1. Ordered List 1 - Item 1
+    1. Ordered List 2 - Item 1
+        1. Ordered List 3 - Item 1
+        2. Ordered List 3 - Item 2
+    2. Ordered List 2 - Item 2
+2. Ordered List 1 - Item 2

--- a/docs/tests/styling/nested.md
+++ b/docs/tests/styling/nested.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Nested lists
+parent: Styling
+grand_parent: Tests
+---
+
+# Nested lists
+
+1. Ordered List 1
+    * Unordered List 1
+        1. Ordered List 2
+            * Unordered List 2
+                * Unordered List 3
+
+----
+
+1. Ordered List 1
+    1. Ordered List 2 - Item 1
+        * Unordered List 1 - Item 1
+        * Unordered List 1 - Item 2
+    2. Ordered List 2 - Item 2

--- a/docs/tests/styling/nested.md
+++ b/docs/tests/styling/nested.md
@@ -20,3 +20,12 @@ grand_parent: Tests
         * Unordered List 1 - Item 1
         * Unordered List 1 - Item 2
     2. Ordered List 2 - Item 2
+
+----
+
+1. Ordered List 1
+    1. Ordered List 2
+        1. Ordered List 3
+            1. Ordered List 4
+                1. Ordered List 5
+                    1. Ordered List 6


### PR DESCRIPTION
Fix #491
- Restrict an `li` style to direct descendants.
- Add the examples from #491 to the regression tests