### PR TITLE
Set color for search input

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -49,6 +49,7 @@
   padding-left: #{$gutter-spacing-sm + $sp-5};
   font-size: 16px;
   background-color: $search-background-color;
+  color: $body-text-color;
   border-top: 0;
   border-right: 0;
   border-bottom: 0;

--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -48,8 +48,8 @@
   padding-bottom: $sp-2;
   padding-left: #{$gutter-spacing-sm + $sp-5};
   font-size: 16px;
-  background-color: $search-background-color;
   color: $body-text-color;
+  background-color: $search-background-color;
   border-top: 0;
   border-right: 0;
   border-bottom: 0;


### PR DESCRIPTION
Fix #497
- Insert `color: $body-text-color;` in styling for `search-input`.