### PR TITLE
docs: Mention caveat about variable dependencies

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -69,9 +69,9 @@ For example, to change the link color from the purple default to blue, include t
 $link-color: $blue-000;
 ```
 
-Keep in mind that changing a variable will not automatically change the value of other variables that depend on in.
-For example, the default link color is set to `$purple-000`, but redefining `$purple-000` in a custom color scheme will not automatically change `$link-color` to match it.
-The cascading of values from a variable that is redefined must be manually reimplemented, by copying the dependent rules from `_variables.scss` — in this case, `$link-color: $purple-000;`.
+Keep in mind that changing a variable will not automatically change the value of other variables that depend on it.
+For example, the default link color (`$link-color`) is set to `$purple-000`. However, redefining `$purple-000` in a custom color scheme will not automatically change `$link-color` to match it.
+Instead, each variable that relies on previously-cascaded values must be manually reimplemented by copying the dependent rules from `_variables.scss` — in this case, rewriting`$link-color: $purple-000;`.
 
 _Note:_ Editing the variables directly in `_sass/support/variables.scss` is not recommended and can cause other dependencies to fail.
 Please use scheme files.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -69,6 +69,10 @@ For example, to change the link color from the purple default to blue, include t
 $link-color: $blue-000;
 ```
 
+Keep in mind that changing a variable will not automatically change the value of other variables that depend on in.
+For example, the default link color is set to `$purple-000`, but redefining `$purple-000` in a custom color scheme will not automatically change `$link-color` to match it.
+The cascading of values from a variable that is redefined must be manually reimplemented, by copying the dependent rules from `_variables.scss` — in this case, `$link-color: $purple-000;`.
+
 _Note:_ Editing the variables directly in `_sass/support/variables.scss` is not recommended and can cause other dependencies to fail.
 Please use scheme files.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -71,7 +71,7 @@ $link-color: $blue-000;
 
 Keep in mind that changing a variable will not automatically change the value of other variables that depend on it.
 For example, the default link color (`$link-color`) is set to `$purple-000`. However, redefining `$purple-000` in a custom color scheme will not automatically change `$link-color` to match it.
-Instead, each variable that relies on previously-cascaded values must be manually reimplemented by copying the dependent rules from `_variables.scss` — in this case, rewriting`$link-color: $purple-000;`.
+Instead, each variable that relies on previously-cascaded values must be manually reimplemented by copying the dependent rules from `_variables.scss` — in this case, rewriting `$link-color: $purple-000;`.
 
 _Note:_ Editing the variables directly in `_sass/support/variables.scss` is not recommended and can cause other dependencies to fail.
 Please use scheme files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3743,9 +3743,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "stylelint": "^13.7.2",
     "@primer/css": "^15.2.0",
-    "prettier": "^2.1.2",
+    "prettier": "^2.5.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-primer": "^9.2.1",
     "stylelint-prettier": "^1.1.2",


### PR DESCRIPTION
Looking at how the variables are defined in `_variables.scss`, with various dependencies between them aimed at ensuring a consistent color scheme, one might expect that redefining a given variable would affect the remaining styles that depend on it.

This is not the case, however, due to the order in which the files are processed. This PR edits the documentation to mention the non-propagating behavior of redefined variables, to better guide users that wish to customize the site using custom themes, and call their attention to the need to redefine the dependency relations as well.