### PR TITLE
feat: support automatic selectable dark theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -125,7 +125,7 @@ callouts:
     color: red
 
 # Dark color scheme; activates auto-switching if not nil. Supports "dark" or a custom color scheme
-dark_color_scheme: nil
+dark_color_scheme: dark
 
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89

--- a/_config.yml
+++ b/_config.yml
@@ -124,6 +124,9 @@ callouts:
     title: Warning
     color: red
 
+# Dark color scheme; activates auto-switching if not nil. Supports "dark" or a custom color scheme
+dark_color_scheme: nil
+
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
 ga_tracking: UA-2709176-10

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -481,4 +481,27 @@ jtd.onReady(function(){
 
 })(window.jtd = window.jtd || {});
 
+{% if site.dark_color_scheme and site.dark_color_scheme != 'nil' -%}
+    if (window.matchMedia) {
+        window.matchMedia('(prefers-color-scheme: dark)')
+              .addEventListener('change', event => {
+          if (event.matches) {
+              jtd.setTheme('{{site.dark_color_scheme}}');
+          } else {
+              {% if site.color_scheme and site.color_scheme != 'nil' -%}
+                  jtd.setTheme('{{site.color_scheme}}');
+              {% else -%}
+                  jtd.setTheme('light');
+              {%- endif %}
+          }
+        });
+    
+        if(window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            jtd.setTheme('{{site.dark_color_scheme}}');
+        }
+    }
+{%- endif %}
+
 {% include js/custom.js %}
+
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,6 +153,16 @@ jtd.addEvent(toggleDarkMode, 'click', function(){
 });
 </script>
 
+You can also have your site auto-switch based on the browser setting:
+
+```yaml
+# The default
+color_scheme: light
+
+# Dark color scheme; activates auto-switching if not empty.
+dark_color_scheme: dark
+```
+
 See [Customization]({{ site.baseurl }}{% link docs/customization.md %}) for more information.
 
 ## Callouts

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -50,6 +50,19 @@ jtd.addEvent(toggleDarkMode, 'click', function(){
 });
 </script>
 
+### Automatic color scheme
+
+If you want your site to react to the user's system light/dark selection, define the `dark_color_scheme` parameter. This will enable automatic switching between `color_scheme` for light mode and `dark_color_scheme` for dark mode.
+
+#### Example
+{: .no_toc}
+
+```yaml
+color_scheme: light
+# Automatically switch to this when a user has a system dark mode enabled
+dark_color_scheme: dark
+```
+
 ## Custom schemes
 
 ### Define a custom scheme


### PR DESCRIPTION
I need to fix `gh` on this computer, it opens mvim and then submits the PR without waiting for this...

Anyway, this closes #234 by adding a `dark_color_scheme` parameter that enables auto-switching to whatever it is set to if it is set.

~~Not really tested yet.~~ I've used this on https://scikit-hep.org, but have not tested the configuration part.