### PR TITLE
Write search-data.json from heredoc in rake search:init

### DIFF
--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README)}i) }
   spec.executables   << 'just-the-docs'
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", "~> 2.2.8" 
   spec.add_runtime_dependency "jekyll", ">= 3.8.5"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1", "< 13.1.0"

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -8,7 +8,8 @@ namespace :search do
     puts 'Generating content...'
 
     File.open('assets/js/zzzz-search-data.json', 'w') do |f|
-      f.puts '---
+      f.puts <<-SEARCH_JS
+---
 permalink: /assets/js/search-data.json
 ---
 {
@@ -31,36 +32,36 @@ permalink: /assets/js/search-data.json
       {%- assign page_content = page.content -%}
       {%- assign heading_level = site.search.heading_level | default: 2 -%}
       {%- for j in (2..heading_level) -%}
-        {%- assign tag = \'<h\' | append: j -%}
-        {%- assign closing_tag = \'</h\' | append: j -%}
-        {%- assign page_content = page_content | replace: tag, \'<h1\' | replace: closing_tag, \'</h1\' -%}
+        {%- assign tag = '<h' | append: j -%}
+        {%- assign closing_tag = '</h' | append: j -%}
+        {%- assign page_content = page_content | replace: tag, '<h1' | replace: closing_tag, '</h1' -%}
       {%- endfor -%}
-      {%- assign parts = page_content | split: \'<h1\' -%}
+      {%- assign parts = page_content | split: '<h1' -%}
       {%- assign title_found = false -%}
       {%- for part in parts offset: 1 -%}
-        {%- assign titleAndContent = part | split: \'</h1>\' -%}
-        {%- assign title = titleAndContent[0] | replace_first: \'>\', \'<h1>\' | split: \'<h1>\' -%}
+        {%- assign titleAndContent = part | split: '</h1>' -%}
+        {%- assign title = titleAndContent[0] | replace_first: '>', '<h1>' | split: '<h1>' -%}
         {%- assign title = title[1] | strip_html -%}
         {%- assign content = titleAndContent[1] -%}
         {%- assign url = page.url -%}
-        {%- if title == page.title and parts[0] == \'\' -%}
+        {%- if title == page.title and parts[0] == '' -%}
           {%- assign title_found = true -%}
         {%- else -%}
           {%- assign id = titleAndContent[0] -%}
-          {%- assign id = id | split: \'id="\' -%}
+          {%- assign id = id | split: 'id="' -%}
           {%- if id.size == 2 -%}
             {%- assign id = id[1] -%}
-            {%- assign id = id | split: \'"\' -%}
+            {%- assign id = id | split: '"' -%}
             {%- assign id = id[0] -%}
-            {%- capture url -%}{{ url | append: \'#\' | append: id }}{%- endcapture -%}
+            {%- capture url -%}{{ url | append: '#' | append: id }}{%- endcapture -%}
           {%- endif -%}
         {%- endif -%}
   {%- unless i == 0 -%},{%- endunless -%}
   "{{ i }}": {
     "doc": {{ page.title | jsonify }},
     "title": {{ title | jsonify }},
-    "content": {{ content | replace: \'</h\', \' . </h\' | replace: \'<hr\', \' . <hr\' | replace: \'</p\', \' . </p\' | replace: \'<ul\', \' . <ul\' | replace: \'</ul\', \' . </ul\' | replace: \'<ol\', \' . <ol\' | replace: \'</ol\', \' . </ol\' | replace: \'</tr\', \' . </tr\' | replace: \'<li\', \' | <li\' | replace: \'</li\', \' | </li\' | replace: \'</td\', \' | </td\' | replace: \'<td\', \' | <td\' | replace: \'</th\', \' | </th\' | replace: \'<th\', \' | <th\' | strip_html | remove: \'Table of contents\' | normalize_whitespace | replace: \'. . .\', \'.\' | replace: \'. .\', \'.\' | replace: \'| |\', \'|\' | append: \' \' | jsonify }},
-    "url": "{{ url | relative_url }}",
+    "content": {{ content | replace: '</h', ' . </h' | replace: '<hr', ' . <hr' | replace: '</p', ' . </p' | replace: '<ul', ' . <ul' | replace: '</ul', ' . </ul' | replace: '<ol', ' . <ol' | replace: '</ol', ' . </ol' | replace: '</tr', ' . </tr' | replace: '<li', ' | <li' | replace: '</li', ' | </li' | replace: '</td', ' | </td' | replace: '<td', ' | <td' | replace: '</th', ' | </th' | replace: '<th', ' | <th' | strip_html | remove: 'Table of contents' | normalize_whitespace | replace: '. . .', '.' | replace: '. .', '.' | replace: '| |', '|' | append: ' ' | jsonify }},
+    "url": "{{ url | absolute_url }}",
     "relUrl": "{{ url }}"
   }
         {%- assign i = i | plus: 1 -%}
@@ -70,8 +71,8 @@ permalink: /assets/js/search-data.json
   "{{ i }}": {
     "doc": {{ page.title | jsonify }},
     "title": {{ page.title | jsonify }},
-    "content": {{ parts[0] | replace: \'</h\', \' . </h\' | replace: \'<hr\', \' . <hr\' | replace: \'</p\', \' . </p\' | replace: \'<ul\', \' . <ul\' | replace: \'</ul\', \' . </ul\' | replace: \'<ol\', \' . <ol\' | replace: \'</ol\', \' . </ol\' | replace: \'</tr\', \' . </tr\' | replace: \'<li\', \' | <li\' | replace: \'</li\', \' | </li\' | replace: \'</td\', \' | </td\' | replace: \'<td\', \' | <td\' | replace: \'</th\', \' | </th\' | replace: \'<th\', \' | <th\' | strip_html | remove: \'Table of contents\' | normalize_whitespace | replace: \'. . .\', \'.\' | replace: \'. .\', \'.\' | replace: \'| |\', \'|\' | append: \' \' | jsonify }},
-    "url": "{{ page.url | relative_url }}",
+    "content": {{ parts[0] | replace: '</h', ' . </h' | replace: '<hr', ' . <hr' | replace: '</p', ' . </p' | replace: '<ul', ' . <ul' | replace: '</ul', ' . </ul' | replace: '<ol', ' . <ol' | replace: '</ol', ' . </ol' | replace: '</tr', ' . </tr' | replace: '<li', ' | <li' | replace: '</li', ' | </li' | replace: '</td', ' | </td' | replace: '<td', ' | <td' | replace: '</th', ' | </th' | replace: '<th', ' | <th' | strip_html | remove: 'Table of contents' | normalize_whitespace | replace: '. . .', '.' | replace: '. .', '.' | replace: '| |', '|' | append: ' ' | jsonify }},
+    "url": "{{ page.url | absolute_url }}",
     "relUrl": "{{ page.url }}"
   }
         {%- assign i = i | plus: 1 -%}
@@ -79,7 +80,8 @@ permalink: /assets/js/search-data.json
     {%- endif -%}
   {%- endfor -%}
 {%- endfor %}
-}'
+}
+SEARCH_JS
     end
     puts 'Done.'
   end


### PR DESCRIPTION
When file `assets/js/zzzz-search-data.json` is created with rake, invalid liquid is created. The problem is unescaped single quotes in the string from which the file is written. To fix this bug, we could simply escape these single quotes. However, this multiline string already contains many escaped single quotes. To avoid such issues in the future, the file is written from a heredoc instead.

Resolves #488
See also #495