### PR TITLE
Page color scheme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,12 +23,6 @@ exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "pac
 , "docs/tests/"
 ]
 
-# Regression tests
-# By default, the pages in /docs/tests are excluded when the ste is built.
-# To include them, comment-out the relevant line above.
-# Uncommenting the following line doesn't work - see https://github.com/jekyll/jekyll/issues/4791
-# include: ["docs/tests/"]
-
 # Set a path/url to a logo that will be displayed instead of the title
 #logo: "/assets/images/just-the-docs.png"
 

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,8 @@
+# For local development _excluding_ the test pages, use the option
+# --config _config.yml,_config_dev.yml
+# See https://stackoverflow.com/a/27400343
+
+url: http://localhost:4000/
+
+# For local development _including_ the test pages, use the option
+# --config _config.yml,_config_dev.yml,_config_test.yml

--- a/_config_tests.yml
+++ b/_config_tests.yml
@@ -1,0 +1,9 @@
+# For local development _including_ the test pages, use the option
+# --config _config.yml,_config_dev.yml,_config_test.yml
+
+exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "package.json", "package-lock.json",  "script/", "LICENSE.txt", "lib/", "bin/", "README.md", "Rakefile"
+# , "docs/tests/"
+]
+
+# Uncommenting the following line doesn't work - see https://github.com/jekyll/jekyll/issues/4791
+# include: ["docs/tests/"]

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,13 @@
 
   <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
 
+  {% if page.color_scheme and page.color_scheme != "nil" %}
+  {% assign page_color_href = '/assets/css/just-the-docs-' 
+      | append: page.color_scheme | append: '.css' | relative_url %}
+  <link rel="stylesheet" href="{{ page_color_href }}">
+  {% else %}
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
+  {% endif %}
 
   {% if site.ga_tracking != nil %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>

--- a/_sass/color_schemes/dark-code.scss
+++ b/_sass/color_schemes/dark-code.scss
@@ -1,0 +1,19 @@
+$body-background-color: $grey-dk-300;
+$sidebar-color: $grey-dk-300;
+$border-color: $grey-dk-200;
+
+$body-text-color: $grey-lt-300;
+$body-heading-color: $grey-lt-000;
+$nav-child-link-color: $grey-dk-000;
+$search-result-preview-color: $grey-dk-000;
+
+$link-color: $blue-000;
+$btn-primary-color: $blue-200;
+$base-button-color: $grey-dk-250;
+
+$search-background-color: $grey-dk-250;
+$table-background-color: $grey-dk-250;
+$feedback-color: darken($sidebar-color, 3%);
+
+@import "../vendor/pygments/css-github/pygments-tomorrow-night";
+$code-background-color: #1d1f21;

--- a/_sass/vendor/pygments/css-github/pygments-tomorrow-night.scss
+++ b/_sass/vendor/pygments/css-github/pygments-tomorrow-night.scss
@@ -1,0 +1,66 @@
+/*! tomorrow night; https://github.com/MozMorris/tomorrow-pygments */
+.highlight, .highlight pre, .highlight table { background: #1d1f21 !important; color: #c5c8c6 !important; }
+.highlight .hll { background-color: #373b41 !important; }
+.highlight .c { color: #969896 !important; } /* Comment */
+.highlight .err { color: #cc6666 !important; } /* Error */
+.highlight .k { color: #b294bb !important; } /* Keyword */
+.highlight .l { color: #de935f !important; } /* Literal */
+.highlight .n, .highlight .h { color: #c5c8c6 !important; } /* Name */
+.highlight .o { color: #8abeb7 !important; } /* Operator */
+.highlight .p { color: #c5c8c6 !important; } /* Punctuation */
+.highlight .cm { color: #969896 !important; } /* Comment.Multiline */
+.highlight .cp { color: #969896 !important; } /* Comment.Preproc */
+.highlight .c1 { color: #969896 !important; } /* Comment.Single */
+.highlight .cs { color: #969896 !important; } /* Comment.Special */
+.highlight .gd { color: #cc6666 !important; } /* Generic.Deleted */
+.highlight .ge { font-style: italic !important; } /* Generic.Emph */
+.highlight .gh { color: #c5c8c6 !important; font-weight: bold !important; } /* Generic.Heading */
+.highlight .gi { color: #b5bd68 !important; } /* Generic.Inserted */
+.highlight .gp { color: #969896 !important; font-weight: bold !important; } /* Generic.Prompt */
+.highlight .gs { font-weight: bold !important; } /* Generic.Strong */
+.highlight .gu { color: #8abeb7 !important; font-weight: bold !important; } /* Generic.Subheading */
+.highlight .kc { color: #b294bb !important; } /* Keyword.Constant */
+.highlight .kd { color: #b294bb !important; } /* Keyword.Declaration */
+.highlight .kn { color: #8abeb7 !important; } /* Keyword.Namespace */
+.highlight .kp { color: #b294bb !important; } /* Keyword.Pseudo */
+.highlight .kr { color: #b294bb !important; } /* Keyword.Reserved */
+.highlight .kt { color: #f0c674 !important; } /* Keyword.Type */
+.highlight .ld { color: #b5bd68 !important; } /* Literal.Date */
+.highlight .m { color: #de935f !important; } /* Literal.Number */
+.highlight .s { color: #b5bd68 !important; } /* Literal.String */
+.highlight .na { color: #81a2be !important; } /* Name.Attribute */
+.highlight .nb { color: #c5c8c6 !important; } /* Name.Builtin */
+.highlight .nc { color: #f0c674 !important; } /* Name.Class */
+.highlight .no { color: #cc6666 !important; } /* Name.Constant */
+.highlight .nd { color: #8abeb7 !important; } /* Name.Decorator */
+.highlight .ni { color: #c5c8c6 !important; } /* Name.Entity */
+.highlight .ne { color: #cc6666 !important; } /* Name.Exception */
+.highlight .nf { color: #81a2be !important; } /* Name.Function */
+.highlight .nl { color: #c5c8c6 !important; } /* Name.Label */
+.highlight .nn { color: #f0c674 !important; } /* Name.Namespace */
+.highlight .nx { color: #81a2be !important; } /* Name.Other */
+.highlight .py { color: #c5c8c6 !important; } /* Name.Property */
+.highlight .nt { color: #8abeb7 !important; } /* Name.Tag */
+.highlight .nv { color: #cc6666 !important; } /* Name.Variable */
+.highlight .ow { color: #8abeb7 !important; } /* Operator.Word */
+.highlight .w { color: #c5c8c6 !important; } /* Text.Whitespace */
+.highlight .mf { color: #de935f !important; } /* Literal.Number.Float */
+.highlight .mh { color: #de935f !important; } /* Literal.Number.Hex */
+.highlight .mi { color: #de935f !important; } /* Literal.Number.Integer */
+.highlight .mo { color: #de935f !important; } /* Literal.Number.Oct */
+.highlight .sb { color: #b5bd68 !important; } /* Literal.String.Backtick */
+.highlight .sc { color: #c5c8c6 !important; } /* Literal.String.Char */
+.highlight .sd { color: #969896 !important; } /* Literal.String.Doc */
+.highlight .s2 { color: #b5bd68 !important; } /* Literal.String.Double */
+.highlight .se { color: #de935f !important; } /* Literal.String.Escape */
+.highlight .sh { color: #b5bd68 !important; } /* Literal.String.Heredoc */
+.highlight .si { color: #de935f !important; } /* Literal.String.Interpol */
+.highlight .sx { color: #b5bd68 !important; } /* Literal.String.Other */
+.highlight .sr { color: #b5bd68 !important; } /* Literal.String.Regex */
+.highlight .s1 { color: #b5bd68 !important; } /* Literal.String.Single */
+.highlight .ss { color: #b5bd68 !important; } /* Literal.String.Symbol */
+.highlight .bp { color: #c5c8c6 !important; } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #cc6666 !important; } /* Name.Variable.Class */
+.highlight .vg { color: #cc6666 !important; } /* Name.Variable.Global */
+.highlight .vi { color: #cc6666 !important; } /* Name.Variable.Instance */
+.highlight .il { color: #de935f !important; } /* Literal.Number.Integer.Long */

--- a/assets/css/just-the-docs-dark-code.scss
+++ b/assets/css/just-the-docs-dark-code.scss
@@ -1,0 +1,3 @@
+---
+---
+{% include css/just-the-docs.scss.liquid color_scheme="dark-code" %}

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -48,6 +48,16 @@ jtd.addEvent(toggleDarkMode, 'click', function(){
 });
 </script>
 
+You can override the configuration setting in the front matter of individual pages:
+
+#### Example
+{: .no_toc }
+
+When the configuration has set `color_scheme: dark`, the following front matter changes it to `light` for that page:
+```yaml
+color_scheme: light
+```
+
 ## Custom schemes
 
 ### Define a custom scheme
@@ -72,14 +82,18 @@ Please use scheme files.
 
 ### Use a custom scheme
 
-To use the custom color scheme, only set the `color_scheme` parameter in your site's `_config.yml` file:
+To use the custom color scheme for all pages, just set the `color_scheme` parameter in your site's `_config.yml` file:
 ```yaml
 color_scheme: foo
 ```
 
+If you want to use a custom scheme in the front matter of individual pages, you need to make it switchable:
+
 ### Switchable custom scheme
 
-If you want to be able to change the scheme dynamically, for example via javascript, just add a file `assets/css/just-the-docs-foo.scss` (replace `foo` by your scheme name)
+If you want to be able to change the scheme dynamically, for example via javascript,
+or in the front matter of individual pages,
+just add a file `assets/css/just-the-docs-foo.scss` (replace `foo` by your scheme name)
 with the following content:`
 
 {% raw %}
@@ -92,6 +106,11 @@ This allows you to switch the scheme via the following javascript.
 
 ```js
 jtd.setTheme('foo');
+```
+
+It also allows you to use the custom scheme in the front matter of individual pages:
+```yaml
+color_scheme: foo
 ```
 
 ## Override and completely custom styles

--- a/docs/tests/styling/color-page-dark-code.md
+++ b/docs/tests/styling/color-page-dark-code.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Color page dark code
+parent: Styling
+grand_parent: Tests
+color_scheme: dark-code
+---
+
+# Color page dark code
+
+This page uses the custom `dark-code` color scheme, set in the front matter:
+
+```yaml
+color_scheme: dark-code
+```

--- a/docs/tests/styling/color-page-dark.md
+++ b/docs/tests/styling/color-page-dark.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Color page dark
+parent: Styling
+grand_parent: Tests
+color_scheme: dark
+---
+
+# Color page dark
+
+This page uses the builtin `dark` color scheme, set in the front matter:
+
+```yaml
+color_scheme: dark
+```

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README)}i) }
   spec.executables   << 'just-the-docs'
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", ">= 2.1.4"
   spec.add_runtime_dependency "jekyll", ">= 3.8.5"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1", "< 13.1.0"


### PR DESCRIPTION
Implements enhancement #574.

Here is an example of a test page using a custom color scheme set in the front matter:

<img width="1063" alt="Screenshot 2021-02-19" src="https://user-images.githubusercontent.com/18308236/108505235-5d032180-72b7-11eb-910a-aa20c1072b1b.png">

To test locally, use `jekyll --config _config.yml,_config_dev.yml,_config_test.yml`.