### PR TITLE
Fixed the incorrect scroll-behavior when using keyboard

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -403,6 +403,7 @@ function searchLoaded(index, docs) {
           if (active.parentElement.previousSibling) {
             var previous = active.parentElement.previousSibling.querySelector('.search-result');
             previous.classList.add('active');
+            previous.scrollIntoView(true);
           }
         }
         return;
@@ -414,6 +415,7 @@ function searchLoaded(index, docs) {
             var next = active.parentElement.nextSibling.querySelector('.search-result');
             active.classList.remove('active');
             next.classList.add('active');
+            next.scrollIntoView(false);
           }
         } else {
           var next = document.querySelector('.search-result');


### PR DESCRIPTION
**File:** `just-the-docs.js` 
**Description:** When using the keyboard to scroll(or change the active search result) inside the search container, a minor behavior issue made the active search results go out of view due to the overflow. This pull request fixes it using the `scrollIntoView` function in js.
