### PR TITLE
sass/color_scheme: Fix dark mode search bar text color.

### DIFF
--- a/_sass/color_schemes/dark.scss
+++ b/_sass/color_schemes/dark.scss
@@ -12,6 +12,7 @@ $btn-primary-color: $blue-200;
 $base-button-color: $grey-dk-250;
 
 $code-background-color: $grey-dk-250;
+$search-text-color: $grey-lt-000;
 $search-background-color: $grey-dk-250;
 $table-background-color: $grey-dk-250;
 $feedback-color: darken($sidebar-color, 3%);

--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -48,6 +48,7 @@
   padding-bottom: $sp-2;
   padding-left: #{$gutter-spacing-sm + $sp-5};
   font-size: 16px;
+  color: $search-text-color;
   background-color: $search-background-color;
   border-top: 0;
   border-right: 0;

--- a/_sass/support/_variables.scss
+++ b/_sass/support/_variables.scss
@@ -33,6 +33,7 @@ $font-size-10-sm: 48px !default;
 //
 
 $white: #fff !default;
+$black: #000 !default;
 
 $grey-dk-000: #959396 !default;
 $grey-dk-100: #5c5962 !default;
@@ -72,6 +73,7 @@ $red-300: #dd2e2e !default;
 
 $body-background-color: $white !default;
 $sidebar-color: $grey-lt-000 !default;
+$search-text-color: $black !default;
 $search-background-color: $white !default;
 $table-background-color: $white !default;
 $code-background-color: $grey-lt-000 !default;


### PR DESCRIPTION
Currently, the search bar's text color in dark mode is black. This is make it hard to see what's being typed. This PR fixes that by keeping the default `black` color in light mode and switching to `$grey-lt-000` in dark mode.

Before:
![Before](https://user-images.githubusercontent.com/29123352/149669654-b9942916-c0f0-4c8e-84fb-6aa339e1fc99.png)

After:
![After](https://user-images.githubusercontent.com/29123352/149669637-19ec33f9-0be6-4bbd-9360-422e5454502f.png)


@pmarsceill could you please look at this when you get the time? It's a pretty small change, so it shouldn't be much of a hassle to review. Thanks for open sourcing this brilliant Jekyll theme!