### PR TITLE
adds 'This site is powered by Netlify.' to the footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,7 +81,7 @@ nav_sort: case_sensitive # Capital letters sorted before lowercase
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a>"
+footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter


### PR DESCRIPTION
This PR adds a small link back to Netlify in the footer (specifically, in the user-editable config); this is a necessary prerequisite for the [Netlify OSS Plan](https://www.netlify.com/legal/open-source-policy). 

See: https://github.com/orgs/just-the-docs/teams/maintainers/discussions/1/comments/18.