### PR TITLE
adds `webrick` to `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
 gemspec
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
This is one solution for #798, namely that `webrick` is needed as an explicit dependency for Ruby 3+.

Closes #798.