### PR TITLE
Mermaid support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -122,3 +122,10 @@ compress_html:
   profile: false
   # ignore:
   #   envs: all
+
+# Enable support for mermaid, defaults to true
+mermaid_enabled: true
+# pick from https://cdnjs.com/libraries/mermaid
+mermaid_version: "9.0.0"
+# choices: https://mermaid-js.github.io/mermaid/#/theming
+mermaid_theme: "forest"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,6 +29,11 @@
   {% if site.search_enabled != false %}
     <script type="text/javascript" src="{{ '/assets/js/vendor/lunr.min.js' | relative_url }}"></script>
   {% endif %}
+
+  {% if site.mermaid_enabled != false %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/{{ site.mermaid_version }}/mermaid.min.js"></script>
+  {% endif %}
+
   <script type="text/javascript" src="{{ '/assets/js/just-the-docs.js' | relative_url }}"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -199,4 +199,18 @@ layout: table_wrappers
     {% endif %}
   </div>
 </body>
+{% if site.mermaid_enabled != false %}
+<script>
+  var config = {
+    startOnLoad:true,
+    theme: '{{ site.mermaid_theme }}',
+    flowchart:{
+      useMaxWidth:false,
+      htmlLabels:true
+    }
+  };
+  mermaid.initialize(config);
+  window.mermaid.init(undefined, document.querySelectorAll('.language-mermaid'));
+</script>
+{% endif %}
 </html>

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -179,3 +179,19 @@ Long, single-line code blocks should not wrap. They should horizontally scroll i
 ```
 The final element.
 ```
+
+### Mermaid
+
+[Mermaid](https://mermaid-js.github.io) examples:
+
+[Flowchart](https://mermaid-js.github.io/mermaid/#/./flowchart?id=flowcharts-basic-syntax)
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
+Online [editor](https://mermaid-js.github.io/mermaid-live-editor/)


### PR DESCRIPTION
https://github.com/just-the-docs/just-the-docs/issues/825

_config.yaml options added:
```
# Enable support for mermaid, defaults to true
mermaid_enabled: true
# pick from https://cdnjs.com/libraries/mermaid
mermaid_version: "9.0.0"
# choices: https://mermaid-js.github.io/mermaid/#/theming
mermaid_theme: "forest"
```
