### PR TITLE
docs: fix spacing in toc example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
 gemspec
+
+gem "webrick", "~> 1.7"

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -257,7 +257,7 @@ To generate a Table of Contents on your docs pages, you can use the `{:toc}` met
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 ```
 
 This example skips the page name heading (`#`) from the TOC, as well as the heading for the Table of Contents itself (`##`) because it is redundant, followed by the table of contents itself. To get an unordered list, replace `1. TOC` above by `- TOC`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3743,9 +3743,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "stylelint": "^13.7.2",
     "@primer/css": "^15.2.0",
-    "prettier": "^2.5.1",
+    "prettier": "^2.6.2",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-primer": "^9.2.1",
     "stylelint-prettier": "^1.1.2",


### PR DESCRIPTION
As is, this is invalid and will not cause the TOC to be rendered. The collapsing example is fine.