### PR TITLE
Anchor heading links should be visible on focus

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -188,6 +188,7 @@
   }
 
   .anchor-heading:hover,
+  .anchor-heading:focus,
   h1:hover > .anchor-heading,
   h2:hover > .anchor-heading,
   h3:hover > .anchor-heading,


### PR DESCRIPTION
The anchor heading item is keyboard focusable, but when focused and not hovered, it is not visible. This PR fixes that. Also, great project!