### PR TITLE
Fix nested task lists (#517)

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -91,6 +91,7 @@
   .task-list-item-checkbox {
     margin-right: 0.6em;
     margin-left: -1.4em;
+    // The same margin-left is used above for ul > li::before
   }
 
   hr + * {

--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -82,13 +82,7 @@
     }
   }
 
-  .task-list {
-    padding-left: 0;
-  }
-
   .task-list-item {
-    display: flex;
-    align-items: center;
 
     &::before {
       content: "";
@@ -97,6 +91,7 @@
 
   .task-list-item-checkbox {
     margin-right: 0.6em;
+    margin-left: -1.4em;
   }
 
   hr + * {

--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -83,7 +83,6 @@
   }
 
   .task-list-item {
-
     &::before {
       content: "";
     }

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -118,6 +118,30 @@ end
 - [ ] Hello, this is another TODO item
 - [x] Goodbye, this item is done
 
+### Nesting task lists
+
+- [ ] level 1 item (task)
+   - [ ] level 2 item (task)
+   - [ ] level 2 item (task)
+- [ ] level 1 item (task)
+- [ ] level 1 item (task)
+
+### Nesting a ul in a task list
+
+- [ ] level 1 item (task)
+   - level 2 item (ul)
+   - level 2 item (ul)
+- [ ] level 1 item (task)
+- [ ] level 1 item (task)
+
+### Nesting a task list in a ul
+
+- level 1 item (ul)
+   - [ ] level 2 item (task)
+   - [ ] level 2 item (task)
+- level 1 item (ul)
+- level 1 item (ul)
+
 ### Small image
 
 ![](../../assets/images/small-image.jpg)


### PR DESCRIPTION
Fix #517

Users expect nested task lists to have the same indentation as other lists.
Fix the styling in `_sass/content.scss` to do that.
Add examples in `docs/index-test.md` to test.