### PR TITLE
Show how to break an ol

### DIFF
--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -89,6 +89,13 @@ Some text
 1.  Item three
 1.  Item four
 
+### And an ordered list starting from 42:
+
+{:style="counter-reset:step-counter 41"}
+1.  Item 42
+1.  Item 43
+1.  Item 44
+
 ### And a nested list:
 
 - level 1 item

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -78,6 +78,17 @@ end
 1.  Item three
 1.  Item four
 
+### And an ordered list, continued:
+
+1.  Item one
+1.  Item two
+
+Some text
+
+{:style="counter-reset:none"}
+1.  Item three
+1.  Item four
+
 ### And a nested list:
 
 - level 1 item


### PR DESCRIPTION
Close #750

The theme uses CSS counters for ordered lists.
So to continue the numbering of an ordered list after a break,
use `style="counter-reset:none"` instead of `start="42"`.
Add the example from #750 to `docs/index-test.md` to test.