### PR TITLE
Change input color according to theme

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -48,6 +48,7 @@
   padding-bottom: $sp-2;
   padding-left: #{$gutter-spacing-sm + $sp-5};
   font-size: 16px;
+  color: $search-result-preview-color;
   background-color: $search-background-color;
   border-top: 0;
   border-right: 0;


### PR DESCRIPTION
This fixes the input color being inaccessible in dark theme:
<img width="618" alt="Screen Shot 2022-06-16 at 17 17 21" src="https://user-images.githubusercontent.com/16595309/174090590-9706d083-67ce-4810-9f6d-e3678116bd39.png">

