### PR TITLE
Fix vertical alignment for consecutive labels

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -224,7 +224,7 @@
       margin-top: 1em;
     }
 
-    + p {
+    + p:not(.label) {
       margin-top: 0;
     }
   }

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -146,6 +146,29 @@ Some text
 
 "[Wroclaw University Library digitizing rare archival texts](https://www.flickr.com/photos/97810305@N08/9401451269)" by [j_cadmus](https://www.flickr.com/photos/97810305@N08) is marked with [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/?ref=openverse).
 
+### Labels
+
+I'm a label
+{: .label }
+
+blue
+{: .label .label-blue }
+green
+{: .label .label-green }
+purple
+{: .label .label-purple }
+yellow
+{: .label .label-yellow }
+red
+{: .label .label-red }
+
+**bold**
+{: .label }
+*italic*
+{: .label }
+***bold + italic***
+{: .label }
+
 ### Definition lists can be used with HTML syntax.
 
 <dl>


### PR DESCRIPTION
Fixes a problem where multiple labels right after a heading are vertically misaligned.

Closes #751.