### PR TITLE
Fix nav scroll feature

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -460,7 +460,7 @@ jtd.setTheme = function(theme) {
 // Scroll site-nav to ensure the link to the current page is visible
 
 function scrollNav() {
-  const href = document.location.href.split('#')[0].replace(/(.+?)\/+$/, "$1");
+  const href = document.location.pathname;
   const siteNav = document.getElementById('site-nav');
   const targetLink = siteNav.querySelector('a[href="' + href + '"], a[href="' + href + '/"]');
   if(targetLink){


### PR DESCRIPTION
The nav scroll feature had stopped working (altogether), due to the change from absolute to relative urls.

This update uses the document location pathname as the `href`. It appears to work when tested, both locally and on the preview.

(Now based on 0.4.0-dev, it replaces #897.)