### PR TITLE
Allow links to wrap

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -19,7 +19,6 @@
   a {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   ul,

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -69,6 +69,12 @@ end
 
 ###### [](#header-6)Header 6
 
+[This is a very long link which wraps and therefore doesn't overflow
+even when it comes at the beginning](.) of the line.
+  
+- [This is a very long link which wraps and therefore doesn't overflow the line
+  when used first in an item ](.) in a list.
+
 | head1        | head two          | three |
 |:-------------|:------------------|:------|
 | ok           | good swedish fish | nice  |


### PR DESCRIPTION
Fix #734.

- Remove `white-space: nowrap;` in `_sass/content.scss`.
- Add an example testing wrapping in`docs/index-test.md`.