### PR TITLE
fix search-input on dark schemes

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -54,6 +54,7 @@
   border-bottom: 0;
   border-left: 0;
   border-radius: 0;
+  color: $body-text-color;
 
   @include mq(md) {
     padding-top: $gutter-spacing-sm;


### PR DESCRIPTION
search input in dark scheme has no color for the text

Signed-off-by: Memet Zx <memetpea25@gmail.com>
