### PR TITLE
Fix TOC on Search

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -5,15 +5,13 @@ nav_order: 7
 ---
 
 # Search
-
 {: .no_toc }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 


### PR DESCRIPTION
Fixes missing TOC on the Search page: https://just-the-docs.github.io/just-the-docs/docs/search/