### PR TITLE
chore: exclude `vendor/` in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ baseurl: "/just-the-docs" # the subpath of your site, e.g. /blog
 url: "https://just-the-docs.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 permalink: pretty
-exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "package.json", "package-lock.json",  "script/", "LICENSE.txt", "lib/", "bin/", "README.md", "Rakefile"]
+exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "package.json", "package-lock.json",  "script/", "LICENSE.txt", "lib/", "bin/", "README.md", "Rakefile", "vendor"]
 
 # Set a path/url to a logo that will be displayed instead of the title
 #logo: "/assets/images/just-the-docs.png"


### PR DESCRIPTION
Building the jekyll site on your own in GitHub workflows fails due missing exclude of `vendor` in `_config.yml`. If someone reuses your `_config.yml` he/she will come across some issues.

Reference: https://github.com/jekyll/jekyll/issues/5267#issuecomment-241379902