### PR TITLE
Fix active grandchild link class

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -111,7 +111,7 @@
                 {%- for grandchild in grandchildren_list -%}
                   {%- unless grandchild.nav_exclude -%}
                   <li class="nav-list-item {% if page.url == grandchild.url %} active{% endif %}">
-                    <a href="{{ grandchild.url | relative_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grandchild.title }}</a>
+                    <a href="{{ grandchild.url | relative_url }}" class="nav-list-link{% if page.url == grandchild.url %} active{% endif %}">{{ grandchild.title }}</a>
                   </li>
                   {%- endunless -%}
                 {%- endfor -%}


### PR DESCRIPTION
An occurrence of `grandchild` was miss-spelled `grand_child` (!). That caused omission of the `active` class in the link in the nav panel for _all_ grandchildren (affecting only the boldness of the displayed links).

This bug was discovered using `diff` to compare [just-the-docs/just-the-docs-tests ](https://github.com/just-the-docs/just-the-docs-tests) sites built using v0.4.0.rc1 and commit  4396b6b1c836f354bb7aa7edc1a06a49f137d615 on the fix-nav-performance PR branch.

The bug is also evident in the nav panel at https://just-the-docs.github.io/just-the-docs/docs/ui-components/code/line-numbers/, which was built after pre-release v0.4.0.rc2.

A simple test of this PR is to compare the above nav panel link for `Code with line numbers` (when that page is selected) with the corresponding link in the preview of this PR.