### PR TITLE
Fix default highlighting in custom color schemes

### DIFF
--- a/_includes/css/just-the-docs.scss.liquid
+++ b/_includes/css/just-the-docs.scss.liquid
@@ -2,6 +2,7 @@
 $logo: "{{ site.logo | relative_url }}";
 {% endif %}
 @import "./support/support";
+@import "./color_schemes/light";
 @import "./color_schemes/{{ include.color_scheme }}";
 @import "./modules";
 {% include css/custom.scss.liquid %}

--- a/_sass/color_schemes/foo.scss
+++ b/_sass/color_schemes/foo.scss
@@ -1,3 +1,2 @@
-
 @import "./color_schemes/dark";
 $link-color: $green-000;

--- a/_sass/color_schemes/foo.scss
+++ b/_sass/color_schemes/foo.scss
@@ -1,0 +1,3 @@
+
+@import "./color_schemes/dark";
+$link-color: $green-000;

--- a/_sass/color_schemes/foo.scss
+++ b/_sass/color_schemes/foo.scss
@@ -1,2 +1,0 @@
-@import "./color_schemes/dark";
-$link-color: $green-000;

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -58,6 +58,17 @@ You can add custom schemes.
 If you want to add a scheme named `foo` (can be any name) just add a file `_sass/color_schemes/foo.scss` (replace `foo` by your scheme name)
 where you override theme variables to change colors, fonts, spacing, etc.
 
+{: .note }
+Since the default color scheme is `light`, your custom scheme is implicitly based on the variable settings used by the `light` scheme.
+
+If you want your custom scheme to be based on the `dark` scheme, you need to start your file with the following line:
+
+```scss
+@import "./color_schemes/dark";
+```
+
+You can define custom schemes based on other custom schemes in the same way.
+
 Available variables are listed in the [\_variables.scss](https://github.com/just-the-docs/just-the-docs/tree/main/_sass/support/_variables.scss) file.
 
 For example, to change the link color from the purple default to blue, include the following inside your scheme file:


### PR DESCRIPTION
Fix #982

The variable settings for highlighting in the default `light` scheme are currently (v0.4.0.rc2) in `_sass/color_schemes/light.scss`. This PR ensures that custom schemes are based on the default `light` scheme.

It also adds a note explaining the default to the customization docs, and gives an example of how to define a custom scheme based on the `dark` scheme.

The example custom scheme `foo` is included in `_sass/color_schemes/foo.scss` to facilitate testing this PR. If you remove the import of the `dark` scheme in that file, and set `_color_scheme: foo` in `_config.yml`, you should see the highlighting from the `light` scheme in the Markdown kitchen sink.

(The example `foo` should probably be removed before merging, to restrict the schemes provided by the theme to `light` and `dark`.)