### PR TITLE
Fix incorrect disambiguation in generated TOCs

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -225,7 +225,7 @@
   {%- if page.has_children == true and page.has_toc != false -%}
     {%- assign toc_list = pages_list
           | where: "parent", page.title
-          | where: "grand_parent", page.parent -%}
+          | where_exp: "item", "item.grand_parent == page.parent" -%}
     {%- if page.child_nav_order == "desc" -%}
       {%- assign toc_list = toc_list | reverse -%}
     {%- endif -%}


### PR DESCRIPTION
The regression tests in https://just-the-docs.github.io/just-the-docs-tests/navigation/grandparent/index/ include a section "A grandchild with the same parent title as a child or top-level page". Its last item fails, as can currently be seen at https://just-the-docs.github.io/just-the-docs-tests/navigation/grandparent/f/ : the first occurrence of `G` links to the grandchild of `E`, and shouldn't be displayed.

The regression can be fixed by changing `where: "grand_parent", page.parent` to `where_exp: "item", "item.grand_parent == page.parent"`. This should be apparent  when running the regressions tests with this PR branch as remote theme.

The two filters give the same results in Jekyll 4, but not in Jekyll 3 (see https://github.com/jekyll/jekyll/pull/7580). It seems that this was overlooked because the hasty sanity-testing of v0.4.0.rc3 was inadvertently using Jekyll 4.2.2.