### PR TITLE
Fix duplicated external links in collections

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -183,15 +183,17 @@
       </li>
     {%- endunless -%}
 {%- endfor -%}
-{%- assign nav_external_links = site.nav_external_links -%}
-{%- for node in nav_external_links -%}
-      <li class="nav-list-item external">
-        <a href="{{ node.url | absolute_url }}" class="nav-list-link external">
-          {{ node.title }}
-          {% unless node.hide_icon %}<svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>{% endunless %}
-        </a>
-      </li>
-{%- endfor -%}
+{%- unless include.key -%}
+  {%- assign nav_external_links = site.nav_external_links -%}
+  {%- for node in nav_external_links -%}
+        <li class="nav-list-item external">
+          <a href="{{ node.url | absolute_url }}" class="nav-list-link external">
+            {{ node.title }}
+            {% unless node.hide_icon %}<svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>{% endunless %}
+          </a>
+        </li>
+  {%- endfor -%}
+{%- endunless -%}
 </ul>
 
 {%- comment -%}

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -252,10 +252,9 @@ aux_links:
 ## External Navigation Links
 
 To add external links to the navigation, add them to the `nav_external_links` [configuration]({{ site.baseurl }}{% link docs/configuration.md %}) option in your site's `_config.yml` file.
-External links will appear under all other items in the listing order.
+External links will appear in the navigation after the links to ordinary pages, but before any collections.
 
 #### Example
-
 {: .no_toc }
 
 ```yaml
@@ -265,6 +264,9 @@ nav_external_links:
     url: https://github.com/just-the-docs/just-the-docs
     hide_icon: false # set to true to hide the external link icon - defaults to false
 ```
+
+The external links are decorated by an icon, which distinguishes them from internal links.
+You can suppress the icon by setting `hide_icon: true`.
 
 ---
 


### PR DESCRIPTION
The navigation should only display the external links once, after the links to pages that are not in collections.

The test for PR #876 at https://just-the-docs.github.io/just-the-docs-tests/navigation/external-links fails with v0.4.0.rc3, and succeeds when the updated `nav.html` is added locally.

The docs need updating to clarify how the interaction between the collections feature and the external links feature is resolved.