### PR TITLE
Fix external links for sites with no pages

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -183,17 +183,6 @@
       </li>
     {%- endunless -%}
 {%- endfor -%}
-{%- unless include.key -%}
-  {%- assign nav_external_links = site.nav_external_links -%}
-  {%- for node in nav_external_links -%}
-        <li class="nav-list-item external">
-          <a href="{{ node.url | absolute_url }}" class="nav-list-link external">
-            {{ node.title }}
-            {% unless node.hide_icon %}<svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>{% endunless %}
-          </a>
-        </li>
-  {%- endfor -%}
-{%- endunless -%}
 </ul>
 
 {%- comment -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,6 +58,18 @@ layout: table_wrappers
       {% if pages_top_size > 0 %}
         {% include nav.html pages=site.html_pages key=nil %}
       {% endif %}
+      {%- if site.nav_external_links -%}
+        <ul class="nav-list">
+          {%- for node in site.nav_external_links -%}
+            <li class="nav-list-item external">
+              <a href="{{ node.url | absolute_url }}" class="nav-list-link external">
+                {{ node.title }}
+                {% unless node.hide_icon %}<svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>{% endunless %}
+              </a>
+            </li>
+          {%- endfor -%}
+        </ul>
+      {%- endif -%}
       {% if site.just_the_docs.collections %}
         {% assign collections_size = site.just_the_docs.collections | size %}
         {% for collection_entry in site.just_the_docs.collections %}


### PR DESCRIPTION
Fix #1020

1.   Move the display of nav external links from `_includes/nav.html` to `_layouts/default.html`.
2.  Replace ` unless include.key` by `if site.nav_external_links`.
3.  Wrap the body of `if site.nav_external_links` in `<ul class="nav-list">…</ul>`.

#### To test this PR:

1.  Add to `_config.yml`:
    ```yaml
    defaults:
      - 
        scope: {path: ""} 
        values: {nav_exclude: true}
    ```
4.  Rebuild the site.
5.  Check that the nav panel displays only external links.