### PR TITLE
Removes `favicon.html`, shifts content to `head_custom.html`

### DIFF
--- a/_includes/favicon.html
+++ b/_includes/favicon.html
@@ -1,1 +1,0 @@
-<link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,8 +10,6 @@
     {% endif %}
   {% endunless %}
 
-  {% include favicon.html %}
-
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
 
   {% if site.ga_tracking != nil %}

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -168,7 +168,7 @@ The (optional) `text-delta` class makes the heading appear as **Contents**{:.tex
 
 This content appears at the bottom of every page's main content. More info for this include can be found in the [Configuration - Footer content]({{ site.baseurl }}{% link docs/configuration.md %}#footer-content).
 
-### Custom Head
+### Custom Head and Favicon
 
 `_includes/head_custom.html`
 
@@ -181,11 +181,14 @@ Note that by default, this file has the following contents:
 ```
 
 #### Example: Custom Favicon
+{: .no_toc }
 
 To add a custom favicon, create `_includes/head_custom.html` and add:
 ```html
-<link rel="shortcut icon" type="image/png" href="{{site.baseurl}}/path/to/your/favicon.png">
+<link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
 ```
+
+If *no favicon* is desired, one needs to have a *blank* `_includes/head_custom.html`.
 
 ### Custom Header
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -174,8 +174,13 @@ This content appears at the bottom of every page's main content. More info for t
 
 Any HTML added to this file will be inserted before the closing `<head>` tag. This might include additional `<meta>`, `<link>`, or `<script>` tags.
 
-#### Example
-{: .no_toc }
+Note that by default, this file has the following contents:
+
+```html
+<link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
+```
+
+#### Example: Custom Favicon
 
 To add a custom favicon, create `_includes/head_custom.html` and add:
 ```html


### PR DESCRIPTION
This continues the conversation in #364: instead of having two different custom includes for favicons, we consolidate to one `head_custom.html` that gets imported last. I also explicitly note this default in the docs, including adding the example to the TOC (since I think this is *so common* that people will search for it).

cc: @pdmosses 

> (interesting aside: perhaps this has performance implications since we kick off the favicon request later in `<head>`, after blocking stylesheets. I wonder if any automated tool / SEO things will dock us here)

So far, I haven't seen anything egregious on Lighthouse, so I'm going to greenlight this for review; happy to be corrected here.