### PR TITLE
analytics: support multiple tracking IDs, document UA -> GA4 switch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -147,7 +147,7 @@ callouts:
     color: red
 
 # Google Analytics Tracking (optional)
-# e.g, UA-1234567-89
+# e.g, UA-1234567-89 or G-1AB234CDE5
 ga_tracking: UA-2709176-10
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
 

--- a/_config.yml
+++ b/_config.yml
@@ -147,7 +147,7 @@ callouts:
     color: red
 
 # Google Analytics Tracking (optional)
-# e.g, UA-1234567-89 or G-1AB234CDE5
+# Supports one tracking ID string (eg. UA-1234567-89 or G-1AB234CDE5) or a list of tracking ID strings
 ga_tracking: UA-2709176-10
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
 

--- a/_config.yml
+++ b/_config.yml
@@ -147,7 +147,7 @@ callouts:
     color: red
 
 # Google Analytics Tracking (optional)
-# Supports one tracking ID string (eg. UA-1234567-89 or G-1AB234CDE5) or a list of tracking ID strings
+# Supports a CSV of tracking ID strings (eg. "UA-1234567-89,G-1AB234CDE5")
 ga_tracking: UA-2709176-10
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
 

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,8 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ include.ga_property }}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', '{{ include.ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
-</script>

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,0 +1,8 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ include.ga_property }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ include.ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,9 +14,7 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', '{{ ga_tracking_ids.first }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
-
-      {% for ga_property in ga_tracking_ids offset:1 %}
+      {% for ga_property in ga_tracking_ids %}
         gtag('config', '{{ ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
       {% endfor %}
     </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,13 +7,19 @@
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
 
   {% if site.ga_tracking != nil %}
-    {% if site.ga_tracking.first %}
-      {% for ga_property in site.ga_tracking %}
-        {% include google_analytics.html ga_property=ga_property %}
+    {% assign ga_tracking_ids = site.ga_tracking | split: "," %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_tracking_ids.first }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '{{ ga_tracking_ids.first }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
+
+      {% for ga_property in ga_tracking_ids offset:1 %}
+        gtag('config', '{{ ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
       {% endfor %}
-    {% else %}
-      {% include google_analytics.html ga_property=site.ga_tracking %}
-    {% endif %}
+    </script>
   {% endif %}
 
   {% if site.search_enabled != false %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,13 @@
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
 
   {% if site.ga_tracking != nil %}
-    {% include google_analytics.html ga_property=site.ga_tracking %}
+    {% if site.ga_tracking.first %}
+      {% for ga_property in site.ga_tracking %}
+        {% include google_analytics.html ga_property=ga_property %}
+      {% endfor %}
+    {% else %}
+      {% include google_analytics.html ga_property=site.ga_tracking %}
+    {% endif %}
   {% endif %}
 
   {% if site.search_enabled != false %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,15 +15,7 @@
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
 
   {% if site.ga_tracking != nil %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', '{{ site.ga_tracking }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
-    </script>
-
+    {% include google_analytics.html ga_property=site.ga_tracking %}
   {% endif %}
 
   {% if site.search_enabled != false %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,11 +210,32 @@ See [Callouts]({{ site.baseurl }}{% link docs/ui-components/callouts.md %}) for 
 
 ## Google Analytics
 
+{: .warning }
+> [Google Analytics 4 will replace Universal Analytics](https://support.google.com/analytics/answer/11583528). On **July 1, 2023**, standard Universal Analytics properties will stop processing new hits. The earlier you migrate, the more historical data and insights you will have in Google Analytics 4.
+
+Universal Analytics (UA) and Google Analytics 4 (GA4) properties are supported.
+
 ```yaml
 # Google Analytics Tracking (optional)
-# e.g, UA-1234567-89
-ga_tracking: UA-5555555-55
-ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true by default)
+# Supports one tracking ID string (eg. UA-1234567-89 or G-1AB234CDE5) or a list of tracking ID strings
+ga_tracking: UA-2709176-10
+ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
+```
+
+You can also list multiple tracking IDs.
+
+This helps seamlessly transition your UA property to a GA4 property by tracking to both for a while.
+
+```yaml
+ga_tracking:
+  - UA-1234567-89
+  - G-1AB234CDE5
+```
+
+Once you've acquired enough data in your GA4 property, you can then retire your UA property.
+
+```yaml
+ga_tracking: G-1AB234CDE5
 ```
 
 ## Document collections

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,7 +222,7 @@ ga_tracking: UA-2709176-10
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
 ```
 
-You can also track multiple tracking IDs. This helps seamlessly transition your UA property to a GA4 property by tracking to both for a while.
+This theme supports multiple comma-separated tracking IDs. This helps seamlessly transition UA properties to GA4 properties by tracking both for a while.
 
 ```yaml
 ga_tracking: "UA-1234567-89,G-1AB234CDE5"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,25 +217,15 @@ Universal Analytics (UA) and Google Analytics 4 (GA4) properties are supported.
 
 ```yaml
 # Google Analytics Tracking (optional)
-# Supports one tracking ID string (eg. UA-1234567-89 or G-1AB234CDE5) or a list of tracking ID strings
+# Supports a CSV of tracking ID strings (eg. "UA-1234567-89,G-1AB234CDE5")
 ga_tracking: UA-2709176-10
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
 ```
 
-You can also list multiple tracking IDs.
-
-This helps seamlessly transition your UA property to a GA4 property by tracking to both for a while.
+You can also track multiple tracking IDs. This helps seamlessly transition your UA property to a GA4 property by tracking to both for a while.
 
 ```yaml
-ga_tracking:
-  - UA-1234567-89
-  - G-1AB234CDE5
-```
-
-Once you've acquired enough data in your GA4 property, you can then retire your UA property.
-
-```yaml
-ga_tracking: G-1AB234CDE5
+ga_tracking: "UA-1234567-89,G-1AB234CDE5"
 ```
 
 ## Document collections


### PR DESCRIPTION
Closes https://github.com/just-the-docs/just-the-docs/issues/1023

It turns out that the Google Analytics scripts are exactly the same for UA and GA4 properties. I am successfully using a GA4 property now on my docs site, as seen in the `<head>`: https://docs.purpleturtlecreative.com/

![Screen Shot 2022-11-05 at 11 23 27 AM](https://user-images.githubusercontent.com/33374343/200127218-bd543587-e180-46f8-96f7-2016c873b5d4.png)