### PR TITLE
Fix duplicate `title` if `jekyll-seo-tag` not in users's plugins

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,14 +2,6 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-  {% unless site.plugins contains "jekyll-seo-tag" %}
-    <title>{{ page.title }} - {{ site.title }}</title>
-
-    {% if page.description %}
-      <meta name="Description" content="{{ page.description }}">
-    {% endif %}
-  {% endunless %}
-
   {% include favicon.html %}
 
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">


### PR DESCRIPTION
As described in  #1008, double title elements will be in the head of a page when 'just-the-docs' is used as a theme by a website, and 'jekyll-seo-tag' is not explicitly listed in the plugins list of that website. In these cases, a title is rendered inside the theme template, but because 'jekyll-seo-tag' is still used at the theme-level, also the seo-tag, including title and meta-description elements would be rendered.

This change implements option 2 described in #1008.

For users that don't have 'jekyll-seo-tag' in their plugins list: Duplicate title and description elements are gone. The title will have a '|' seperator instead of '-'
For users that do have 'jekyll-seo-tag' in their plugins list: Everything stays the same.

Fixes #1008