### PR TITLE
bump JS CI Node version to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Node 18 has been stable for a while, so I feel comfortable making this switch; should be no downstream impact other than speed!