### PR TITLE
sass: remove all uses of `/` as SASS division

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -73,19 +73,19 @@
 
       width: $nav-list-item-height-sm;
       height: $nav-list-item-height-sm;
-      padding-top: #{$nav-list-item-height-sm / 4};
-      padding-right: #{$nav-list-item-height-sm / 4};
-      padding-bottom: #{$nav-list-item-height-sm / 4};
-      padding-left: #{$nav-list-item-height-sm / 4};
+      padding-top: #{$nav-list-item-height-sm * 0.25};
+      padding-right: #{$nav-list-item-height-sm * 0.25};
+      padding-bottom: #{$nav-list-item-height-sm * 0.25};
+      padding-left: #{$nav-list-item-height-sm * 0.25};
       color: $link-color;
 
       @include mq(md) {
         width: $nav-list-item-height;
         height: $nav-list-item-height;
-        padding-top: #{$nav-list-item-height / 4};
-        padding-right: #{$nav-list-item-height / 4};
-        padding-bottom: #{$nav-list-item-height / 4};
-        padding-left: #{$nav-list-item-height / 4};
+        padding-top: #{$nav-list-item-height * 0.25};
+        padding-right: #{$nav-list-item-height * 0.25};
+        padding-bottom: #{$nav-list-item-height * 0.25};
+        padding-left: #{$nav-list-item-height * 0.25};
       }
 
       &:hover {

--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -6,7 +6,7 @@
   flex-grow: 1;
   height: $sp-10;
   padding: $sp-2;
-  transition: padding linear #{$transition-duration / 2};
+  transition: padding linear #{$transition-duration * 0.5};
 
   @include mq(md) {
     position: relative !important;
@@ -24,7 +24,7 @@
   overflow: hidden;
   border-radius: $border-radius;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
-  transition: height linear #{$transition-duration / 2};
+  transition: height linear #{$transition-duration * 0.5};
 
   @include mq(md) {
     position: absolute;
@@ -60,7 +60,7 @@
     padding-left: #{$gutter-spacing + $sp-5};
     font-size: 14px;
     background-color: $body-background-color;
-    transition: padding-left linear #{$transition-duration / 2};
+    transition: padding-left linear #{$transition-duration * 0.5};
   }
 
   &:focus {
@@ -80,7 +80,7 @@
 
   @include mq(md) {
     padding-left: $gutter-spacing;
-    transition: padding-left linear #{$transition-duration / 2};
+    transition: padding-left linear #{$transition-duration * 0.5};
   }
 
   .search-icon {
@@ -240,7 +240,7 @@
   height: $sp-9;
   background-color: $search-background-color;
   border: 1px solid rgba($link-color, 0.3);
-  border-radius: #{$sp-9 / 2};
+  border-radius: #{$sp-9 * 0.5};
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
   align-items: center;
   justify-content: center;

--- a/_sass/support/_functions.scss
+++ b/_sass/support/_functions.scss
@@ -1,5 +1,7 @@
+@use "sass:math";
+
 @function rem($size, $unit: "") {
-  $rem-size: $size / $root-font-size;
+  $rem-size: math.div($size, $root-font-size);
 
   @if $unit == false {
     @return #{$rem-size};


### PR DESCRIPTION
@pdmosses noticed that we have deprecation warnings on some of our SASS code. After testing locally, all of them have to do with using `/` as division in SASS, which is [deprecated](https://sass-lang.com/documentation/breaking-changes/slash-div) (since there's some lexical ambiguity). 

SASS has a nifty [migrator tool](https://github.com/sass/migrator). I used the migrator piecewise on each deprecation warning (since the global usage fails on some liquid code). Upon manual inspection, I think there are no false positives. Running `bundle exec jekyll serve` after a fresh install and `bundle update` no longer emits any warnings.

Closes #1073; blocked by #1072 (CI failure).