### PR TITLE
docs(collections): Add warning about mandatory `_`-prefix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,6 +233,9 @@ ga_tracking: "UA-1234567-89,G-1AB234CDE5"
 By default, the navigation and search include normal [pages](https://jekyllrb.com/docs/pages/).
 You can also use [Jekyll collections](https://jekyllrb.com/docs/collections/) which group documents semantically together.
 
+{: .warning }
+> Collection folders always start with an underscore (`_`), e.g. `_tests`. You won't see your collections if you skip the prefix.
+
 For example, put all your test files in the `_tests` folder and create the `tests` collection:
 
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,7 +234,7 @@ By default, the navigation and search include normal [pages](https://jekyllrb.co
 You can also use [Jekyll collections](https://jekyllrb.com/docs/collections/) which group documents semantically together.
 
 {: .warning }
-> Collection folders always start with an underscore (`_`), e.g. `_tests`. You won't see your collections if you skip the prefix.
+> Collection folders always start with an underscore (`_`), e.g. `_tests`. You won't see your collections if you omit the prefix.
 
 For example, put all your test files in the `_tests` folder and create the `tests` collection:
 


### PR DESCRIPTION
This prefix is required by jekyll. I'd add it here as well to avoid confusion, since users might miss that part.