### PR TITLE
Skip nav collection generation when site has no pages

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -39,21 +39,23 @@
   pages.
 {%- endcomment -%}
 
-{%- assign unsorted_pages = title_pages
-      | where_exp: "item", "item.parent == nil" 
-      | where_exp: "item", "item.nav_exclude == true"-%}
-{%- assign title_pages_size = title_pages.size -%}
-{%- assign unsorted_pages_percent = unsorted_pages.size
-      | times: 100 | divided_by: title_pages_size -%}
-{%- if unsorted_pages_percent > 50 -%}
-  {%- assign sorted_pages = "" | split: "" -%}
-  {%- for item in title_pages -%}
-    {%- if item.nav_exclude != true or item.parent -%}
-      {%- assign sorted_pages = sorted_pages | push: item -%}
-    {%- endif -%}
-  {%- endfor -%}
-  {%- assign title_pages = sorted_pages -%}
-{%- endif -%}
+{%- unless title_pages == empty -%}
+  {%- assign unsorted_pages = title_pages
+        | where_exp: "item", "item.parent == nil" 
+        | where_exp: "item", "item.nav_exclude == true" -%}
+  {%- assign title_pages_size = title_pages.size -%}
+  {%- assign unsorted_pages_percent = unsorted_pages.size
+        | times: 100 | divided_by: title_pages_size -%}
+  {%- if unsorted_pages_percent > 50 -%}
+    {%- assign sorted_pages = "" | split: "" -%}
+    {%- for item in title_pages -%}
+      {%- if item.nav_exclude != true or item.parent -%}
+        {%- assign sorted_pages = sorted_pages | push: item -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- assign title_pages = sorted_pages -%}
+  {%- endif -%}
+{%- endunless -%}
 
 {%- assign nav_order_pages = title_pages
       | where_exp: "item", "item.nav_order != nil"  -%}


### PR DESCRIPTION
Fix issue #1085

The user's config specified collections, but they had no pages. Trying to build the site resulted in Jekyll failing due to a Liquid error. The error report mentioned division by zero, but not that this was due to an empty collection.

Liquid fails with division by 0 when title_pages_size is 0. This fix guards the code that contains the division using a check that title_pages is non-empty.

To test:

1.  Specify a Jekyll collection with no pages, and specify it as a JTD collection.
2. Build the site.
3. Check that the build is successful, and that the specified collection has no nav links to pages.