### PR TITLE
Restore simple configuration of favicon.ico

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,6 +29,15 @@
   <script src="{{ '/assets/js/just-the-docs.js' | relative_url }}"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  {% for file in site.static_files %}
+    {% if file.path == site.favicon_ico or file.path == '/favicon.ico' %}
+      {% assign favicon = true %}
+    {% endif %}
+  {% endfor %}
+  {% if favicon %}
+    <link rel="icon" href="{{ site.favicon_ico | default: '/favicon.ico' | relative_url }}" type="image/x-icon">
+  {% endif %}
 
   {% seo %}
 

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,1 +1,0 @@
-<link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,15 @@ View this site's [\_config.yml](https://github.com/just-the-docs/just-the-docs/t
 logo: "/assets/images/just-the-docs.png"
 ```
 
+## Site favicon
+
+```yaml
+# Set a path/url to a favicon that will be displayed by the browser
+favicon_ico: "/assets/images/favicon.ico"
+```
+
+If the path to your favicon is `/favicon.ico`, you can leave `favicon_ico` unset.
+
 ## Search
 
 ```yaml

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -167,34 +167,13 @@ The (optional) `text-delta` class makes the heading appear as **Contents**{:.tex
 
 This content appears at the bottom of every page's main content. More info for this include can be found in the [Configuration - Footer content]({{ site.baseurl }}{% link docs/configuration.md %}#footer-content).
 
-### Custom Head and Favicon
+### Custom Head
 
 `_includes/head_custom.html`
 
 Any HTML added to this file will be inserted before the closing `<head>` tag. This might include additional `<meta>`, `<link>`, or `<script>` tags.
 
-Note that by default, this file has the following contents:
-
-{% raw %}
-
-```html
-<link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
-```
-{% endraw %}
-
-#### Example: Custom Favicon
-{: .no_toc }
-
-To add a custom favicon, create `_includes/head_custom.html` and add:
-
-{% raw %}
-
-```html
-<link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
-```
-{% endraw %}
-
-If *no favicon* is desired, one needs to have a *blank* `_includes/head_custom.html`.
+The `<head>` tag automatically includes a link to an existing favicon if you set `favicon_ico` to the corresponding path in your configuration, or if the path to the favicon is `/favicon.ico`.
 
 ### Custom Header
 


### PR DESCRIPTION
Avoid the need to add a link to favicon.ico when editing `_includes/head_custom.html`, and avoid creating an invalid favicon link

- Remove the content of `_includes/head_custom.html`
- Add code to `_includes/head.html` to create a link to an existing favicon.ico
- Add an explanation of the use of `favicon_ico` to docs/configuration.md
- Remove the example of `_includes/head_custom.html`, and add an explanation of what the `<head>` element automatically includes, in docs/customization.md

See [this comment](https://github.com/just-the-docs/just-the-docs/commit/845cd763f3b3cac052e333df3559dcc4c9a3383a#r93414412) by @MichelleBlanchette and my subsequent comments for some background.

To some extent, this PR reverts PR #1027.

### To test

1.  Build and serve this PR branch locally.

1.  Move `favicon.ico` to `assets/images/`, then rebuild this website.

1.  Check that the favicon has disappeared, and that Jekyll does *not* report "ERROR '/favicon.ico' not found".

1.  Set `favicon_ico: /assets/images/favicon.ico` in `_config.yml`, then rebuild this website.

1.  Check that the favicon has reappeared.

1.  Move the favicon back to the root directory, and remove the setting of `favicon_ico`.
