### PR TITLE
Fix incorrect `padding` property value pair in `labels.scss`

### DIFF
--- a/_sass/labels.scss
+++ b/_sass/labels.scss
@@ -3,7 +3,7 @@
 .label,
 .label-blue {
   display: inline-block;
-  padding-top: 0.16em 0.56em;
+  padding: 0.16em 0.56em;
   margin-right: $sp-2;
   margin-left: $sp-2;
   color: $white;


### PR DESCRIPTION
This PR corrects the change to `/_sass/labels.scss` made in 551398f92fc125f4692e49d636d2625ca2bf3819. This change tried to set the `padding-**top**` property to **two** values rather than set the `padding` property to these values (to represent the vertical and horizontal padding values). 

It looks like this change should have been caught by CI, but `stylelint` doesn't flag for this. 