### PR TITLE
Replace inline styling for `<svg>` icons

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@ layout: table_wrappers
 {% include head.html %}
 <body>
   <a class="skip-to-main" href="#main-content">Skip to main content</a>
-  <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <svg xmlns="http://www.w3.org/2000/svg">
     <symbol id="svg-link" viewBox="0 0 24 24">
       <title>Link</title>
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@ layout: table_wrappers
 {% include head.html %}
 <body>
   <a class="skip-to-main" href="#main-content">Skip to main content</a>
-  <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0">
+  <svg xmlns="http://www.w3.org/2000/svg" class="d-none" >
     <symbol id="svg-link" viewBox="0 0 24 24">
       <title>Link</title>
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@ layout: table_wrappers
 {% include head.html %}
 <body>
   <a class="skip-to-main" href="#main-content">Skip to main content</a>
-  <svg xmlns="http://www.w3.org/2000/svg">
+  <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0">
     <symbol id="svg-link" viewBox="0 0 24 24">
       <title>Link</title>
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link">


### PR DESCRIPTION
<symbol> elements should never be rendered, so the display:none is not needed ideally. But the <svg> default height/width still needs to be overwritten.

Ref: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol

We use a CSP to avoid inline styles at endoflife.date, so this raises a warning.