### PR TITLE
Fix incorrect `padding` property value pair in `search.scss`

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -123,7 +123,7 @@
 
 .search-result {
   display: block;
-  padding-top: $sp-1 $sp-3;
+  padding: $sp-1 $sp-3;
 
   &:hover,
   &.active {


### PR DESCRIPTION
I just reviewed 551398f and believe that this should be the other half of the fix proposed by just-the-docs/just-the-docs#1104.

This PR corrects the change to `/_sass/search.scss` made in 551398f. This change tried to set the `padding-top` property to **two** values rather than set the `padding` property to these values (to represent the vertical and horizontal padding values).