### PR TITLE
Fix dark theme's code block background, line number colors

### DIFF
--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -207,4 +207,14 @@ code.language-mermaid {
   border: 0;
 }
 
+// Override OneDarkJekyll Colors for Code Blocks
+.highlight, pre.highlight {
+  background: $code-background-color; // Code Background
+  color: $body-text-color; // Line Numbers
+}
+.highlight pre {
+  background: $code-background-color; // Code Background
+}
+
+
 // {% endraw %}

--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -208,13 +208,20 @@ code.language-mermaid {
 }
 
 // Override OneDarkJekyll Colors for Code Blocks
-.highlight, pre.highlight {
+.highlight,
+pre.highlight {
   background: $code-background-color; // Code Background
-  color: $body-text-color; // Line Numbers
+  // For Backwards Compatibility Before $code-linenumber-color was added
+  @if variable-exists(code-linenumber-color) {
+    color: $code-linenumber-color; // Code Line Numbers
+  } @else {
+    color: $body-text-color; // Code Line Numbers
+  }
 }
+
+// Override OneDarkJekyll Colors for Code Blocks
 .highlight pre {
   background: $code-background-color; // Code Background
 }
-
 
 // {% endraw %}

--- a/_sass/color_schemes/dark.scss
+++ b/_sass/color_schemes/dark.scss
@@ -16,13 +16,17 @@ $feedback-color: darken($sidebar-color, 3%);
 
 // @import "./vendor/OneDarkJekyll/syntax-one-dark";
 // $code-background-color: #282c34; // OneDarkJekyll default for syntax-one-dark
+// $code-linenumber-color: #abb2bf; // OneDarkJekyll .nf for syntax-one-dark
 
 @import "./vendor/OneDarkJekyll/syntax-one-dark-vivid";
+
 $code-background-color: #31343f; // OneDarkJekyll default for syntax-one-dark-vivid
+$code-linenumber-color: #dee2f7; // OneDarkJekyll .nf for syntax-one-dark-vivid
 
 // @import "./vendor/OneDarkJekyll/syntax-firewatch";
 // $code-background-color: #282c34; // OneDarkJekyll default for syntax-firewatch
+// $code-linenumber-color: #abb2bf; // OneDarkJekyll .nf for syntax-firewatch
 
 // @import "./vendor/OneDarkJekyll/syntax-firewatch-green";
 // $code-background-color: #282c34; // OneDarkJekyll default for syntax-firewatch-green
-
+// $code-linenumber-color: #abb2bf; // OneDarkJekyll .nf for syntax-firewatch-green

--- a/_sass/color_schemes/dark.scss
+++ b/_sass/color_schemes/dark.scss
@@ -15,14 +15,14 @@ $feedback-color: darken($sidebar-color, 3%);
 // The following highlight theme is more legible than that used for the light color scheme
 
 // @import "./vendor/OneDarkJekyll/syntax-one-dark";
-// $code-background-color: #282c34;
+// $code-background-color: #282c34; // OneDarkJekyll default for syntax-one-dark
 
 @import "./vendor/OneDarkJekyll/syntax-one-dark-vivid";
-
-$code-background-color: #31343f;
+$code-background-color: #31343f; // OneDarkJekyll default for syntax-one-dark-vivid
 
 // @import "./vendor/OneDarkJekyll/syntax-firewatch";
-// $code-background-color: #282c34;
+// $code-background-color: #282c34; // OneDarkJekyll default for syntax-firewatch
 
 // @import "./vendor/OneDarkJekyll/syntax-firewatch-green";
-// $code-background-color: #282c34;
+// $code-background-color: #282c34; // OneDarkJekyll default for syntax-firewatch-green
+

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/just-the-docs/just-the-docs",
   }
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets/[^i]|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
   spec.executables   << 'just-the-docs'
 
   spec.add_development_dependency "bundler", "~> 2.3.5"

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/just-the-docs/just-the-docs",
   }
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets/[^i]|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
   spec.executables   << 'just-the-docs'
 
   spec.add_development_dependency "bundler", "~> 2.3.5"


### PR DESCRIPTION
When customizing `$code-background-color` in `dark.scss`, the result is a multi-color background. (see https://github.com/just-the-docs/just-the-docs/issues/1121#issuecomment-1374976843)

This makes OneDarkJekyll code block colors the same as the specified `$code-background-color`, and uses the `$default-body-color` as the line number text color, which can otherwise be invisible due to the default being black and is hard to see on a very dark code block background.

Also, `.jpg` images from just-the-docs propagate into the `_site` directory of projects created from this gem. This excludes the `assets/images` directory from being included when the gem is built by excluding any directories in the `assets` directory that start with `i`. There might be a more sustainable way to implement this but this does the trick.