### PR TITLE
move kramdown footnotes into JTD <footer>

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -1,7 +1,10 @@
 {% capture footer_custom %}
   {%- include footer_custom.html -%}
 {% endcapture %}
-{% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link %}
+{% capture kd_footnotes %}
+  {%- include components/kramdown_footnotes.html html=content method="extract" -%}
+{% endcapture %}
+{% if footer_custom != "" or kd_footnotes != "" or site.last_edit_timestamp or site.gh_edit_link %}
   <hr>
   <footer>
     {% if site.back_to_top %}
@@ -9,6 +12,7 @@
     {% endif %}
 
     {{ footer_custom }}
+    {{ kd_footnotes }}
 
     {% if site.last_edit_timestamp or site.gh_edit_link %}
       <div class="d-flex mt-2">

--- a/_includes/components/kramdown_footnotes.html
+++ b/_includes/components/kramdown_footnotes.html
@@ -14,7 +14,7 @@
     {% endcomment -%}
     {%- assign footnote_end = footnote_open[1] | split: '</ol>
 </div>' -%}
-    {%- if include.method == "extract" -%}
+    {%- if include.method == "extract" and footnote_end[0] -%}
         <div class="footnotes" role="doc-endnotes">{{- footnote_end[0] -}}</ol></div>
     {%- elsif include.method == "delete" -%}
         {{- footnote_open[0] }}{{ footnote_end[1] -}}

--- a/_includes/components/kramdown_footnotes.html
+++ b/_includes/components/kramdown_footnotes.html
@@ -1,0 +1,22 @@
+{% comment %}
+# Extract or delete kramdown footnote div block
+
+# Brittle. It relies on exact kramdown footnote div structure
+# Alternative: create a gem to delete and extract element(s) by DOM
+# https://www.rubydoc.info/gems/jekyll-extract-element/0.0.7/JekyllExtractElement
+# https://stackoverflow.com/questions/13319407/remove-specific-html-elements-in-ruby
+{% endcomment -%}
+
+{%- if include.html && include.method -%}
+    {%- assign footnote_open = include.html | split: '<div class="footnotes" role="doc-endnotes">' -%}
+    {% comment %}
+    # split only on '</div>' forbids div's in footnotes which felt too restrictive
+    {% endcomment -%}
+    {%- assign footnote_end = footnote_open[1] | split: '</ol>
+</div>' -%}
+    {%- if include.method == "extract" -%}
+        <div class="footnotes" role="doc-endnotes">{{- footnote_end[0] -}}</ol></div>
+    {%- elsif include.method == "delete" -%}
+        {{- footnote_open[0] }}{{ footnote_end[1] -}}
+    {%- endif -%}
+{%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,10 +15,13 @@ layout: table_wrappers
     <div id="main-content-wrap" class="main-content-wrap">
       {% include components/breadcrumbs.html %}
       <div id="main-content" class="main-content" role="main">
+        {% capture content_no_footnotes %}
+          {%- include components/kramdown_footnotes.html html=content method="delete" -%}
+        {% endcapture %}
         {% if site.heading_anchors != false %}
-          {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
+          {% include vendor/anchor_headings.html html=content_no_footnotes beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
         {% else %}
-          {{ content }}
+          {{ content_no_footnotes }}
         {% endif %}
 
         {% if page.has_children == true and page.has_toc != false %}

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -215,6 +215,17 @@ red
 ***bold + italic***
 {: .label }
 
+### Footnotes
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.[^dark]
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[^123]
+
+[^dark]:
+    Sed ut perspiciatis unde omnis iste natus error sit `voluptatem` accusantium doloremque laudantium, totam rem aperiam, `eaque ipsa` quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+
+[^123]: Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis 123.
+
 ### Definition lists can be used with HTML syntax.
 
 <dl>


### PR DESCRIPTION
- fixes just-the-docs/just-the-docs#1084
- add footnote examples to kitchen sink

Moving the footnotes to the `<footer>` exposes a layout concern of mine.
At a minimum, tell me in what position you want these kramdown footnotes.
Overall, I suggest the order of content in the JTD `<footer>` be reviewed by the core JTD team.

The item that I like least is `back-to-top`. Current JTD puts that as the first content in the footer. To me, 'back to top' is a link at the very bottom that I can click after all "content". It doesn't align with that when back-to-top link is before much content (footer_custom, footnotes, timestamp, github edit, etc.). Here is an example of the updated kitchen sink page in the docs.

![image](https://user-images.githubusercontent.com/679350/211373442-a5f2b78e-ea32-4f52-997a-afa15646930b.png)

Personally, I prefer a layout more like...

Sidebar | Main pane |  
-- | -- | --
  | Footnotes |  
  | footer_custom |  
  | Back-to-top | Edit this page
