### PR TITLE
Update view typography utilities button link

### DIFF
--- a/docs/ui-components/typography.md
+++ b/docs/ui-components/typography.md
@@ -111,4 +111,4 @@ Text can be **bold**, _italic_, or ~~strikethrough~~.
 
 There are a number of specific typographic CSS classes that allow you to override default styling for font size, font weight, line height, and capitalization.
 
-[View typography utilities]({{ site.baseurl }}{% link docs/utilities/utilities.md %}#typography){: .btn .btn-outline }
+[View typography utilities]({{ site.baseurl }}{% link docs/utilities/typography.md %}){: .btn .btn-outline }


### PR DESCRIPTION
The typography utilities page has been moved sopme time ago, but the button URL was not updated. This commit fixes the broken link.