### PR TITLE
Exclude images from being bundled with gem

### DIFF
--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/just-the-docs/just-the-docs",
   }
 
-  spec.files         = `git ls-files -z ':!:*.ico' ':!:*.jpg' ':!:*.png' ':!:*.svg'`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
+  spec.files         = `git ls-files -z ':!:*.ico' ':!:*.jpg' ':!:*.png'`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
   spec.executables   << 'just-the-docs'
 
   spec.add_development_dependency "bundler", "~> 2.3.5"

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/just-the-docs/just-the-docs",
   }
 
-  spec.files         = `git ls-files -z ':!:*.ico' ':!:*.jpg' ':!:*.png'`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
+  spec.files         = `git ls-files -z ':!:*.jpg' ':!:*.png'`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
   spec.executables   << 'just-the-docs'
 
   spec.add_development_dependency "bundler", "~> 2.3.5"

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/just-the-docs/just-the-docs",
   }
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
+  spec.files         = `git ls-files -z ':!:*.ico' ':!:*.jpg' ':!:*.png' ':!:*.svg'`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
   spec.executables   << 'just-the-docs'
 
   spec.add_development_dependency "bundler", "~> 2.3.5"


### PR DESCRIPTION
PR #1124 was split into two PRs, this being one of them. This excludes images from being included in the gem file which propagates to downstream sites. `search.svg` is the only image file remaining which is used in downstream sites, although I couldn't find it referenced anywhere in the project, and excluding it doesn't appear to negatively impact downstream sites. In addition, `search.svg` doesn't appear to be the same search icon used in the search input of downstream sites: They are different orientations and shapes/sizes.

This excludes from downstream sites:
```
assets/images/large-image.jpg
assets/images/small-image.jpg
favicon.ico
```