### PR TITLE
Fix copy code button interaction with kramdown line numbers

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -504,7 +504,7 @@ jtd.onReady(function(){
 
     copyButton.addEventListener('click', function () {
       if(timeout === null) {
-        var code = codeBlock.querySelector('pre:not(.lineno)').innerText;
+        var code = (codeBlock.querySelector('pre:not(.lineno, .highlight)') || codeBlock.querySelector('code')).innerText;
         window.navigator.clipboard.writeText(code);
 
         copyButton.innerHTML = svgCopied;


### PR DESCRIPTION
Closes #1121.

Tested locally with the test case provided by @m-r-mccormick and confirms that it resolves the bug. Other examples (ex [deploy preview's kitchen sink](https://deploy-preview-1143--just-the-docs.netlify.app/docs/index-test/)) still work properly.