### PR TITLE
Add configuration key to load a local version of mermaid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,8 @@ mermaid:
   version: "9.1.6"
   # Put any additional configuration, such as setting the theme, in _includes/mermaid_config.js
   # See also docs/ui-components/code
+  # To load mermaid from a local file use the `path` key to specify the location of the library instead; e.g.
+  # path: "/assets/js/mermaid.min.js"
 
 # Enable or disable heading anchors
 heading_anchors: true

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,13 +23,17 @@
   {% endif %}
 
   {% if site.mermaid %}
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@{{ site.mermaid.version }}/dist/mermaid.min.js"></script>
+    {% if site.mermaid.path %}
+      <script src="{{ site.mermaid.path | relative_url }}"></script>
+    {% else %}
+      <script src="https://cdn.jsdelivr.net/npm/mermaid@{{ site.mermaid.version }}/dist/mermaid.min.js"></script>
+    {% endif %}
   {% endif %}
 
   <script src="{{ '/assets/js/just-the-docs.js' | relative_url }}"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
+
   {% for file in site.static_files %}
     {% if file.path == site.favicon_ico or file.path == '/favicon.ico' %}
       {% assign favicon = true %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,8 @@ mermaid:
   version: "9.1.3"
 ```
 
+Provide a `path` instead of a `version` key to load the mermaid library from a local file.
+
 See [the Code documentation]({% link docs/ui-components/code.md %}#mermaid-diagram-code-blocks) for more configuration options and information.
 
 ## Aux links

--- a/docs/ui-components/code.md
+++ b/docs/ui-components/code.md
@@ -146,6 +146,16 @@ graph TD;
     C-->D;
 ```
 
+### Using a local mermaid library
+
+In order to use a local version of the mermaid library instead of one provided by jsDelivr, you can specify a `path` key in the mermaid configuration instead of a `version` key.
+
+```yaml
+mermaid:
+  # To load mermaid from a local file use the `path` key to specify the location of the library instead; e.g.
+  path: "/assets/js/mermaid.min.js"
+```
+
 *Note: for demonstration purposes, we've enabled mermaid on this site. It is still disabled by default, and users need to opt-in to use it.*
 
 ## Copy button

--- a/docs/ui-components/code.md
+++ b/docs/ui-components/code.md
@@ -146,6 +146,8 @@ graph TD;
     C-->D;
 ```
 
+*Note: for demonstration purposes, we've enabled mermaid on this site. It is still disabled by default, and users need to opt-in to use it.*
+
 ### Using a local mermaid library
 
 In order to use a local version of the mermaid library instead of one provided by jsDelivr, you can specify a `path` key in the mermaid configuration instead of a `version` key.
@@ -155,8 +157,6 @@ mermaid:
   # To load mermaid from a local file use the `path` key to specify the location of the library instead; e.g.
   path: "/assets/js/mermaid.min.js"
 ```
-
-*Note: for demonstration purposes, we've enabled mermaid on this site. It is still disabled by default, and users need to opt-in to use it.*
 
 ## Copy button
 {: .d-inline-block }


### PR DESCRIPTION
Hi there!

Thank you for the great theme! I am a happy user and was delighted to see that mermaid support has landed.

In some cases the usage of jsDelivr might not be possible for technical or compliance reasons.

This commit adds a second way to include the mermaid lib by specifying a path in the mermaid config. This way a local version of the lib can be used.

It should be fully backwards compatible, not requiring any action by users that already include the lib from the CDN.

I already added some documentation, but I am also happy to extend this, if this change is generally well-received.


Cheers,
Christian