### PR TITLE
feat: add `gh_edit_collections_dir`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -129,6 +129,7 @@ gh_edit_link_text: "Edit this page on GitHub"
 gh_edit_repository: "https://github.com/just-the-docs/just-the-docs" # the github URL for your repo
 gh_edit_branch: "main" # the branch that your docs is served from
 # gh_edit_source: docs # the source that your files originate from
+# gh_edit_collections_dir: . # the directory that your collections stored at
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -25,7 +25,7 @@
           site.gh_edit_view_mode
         %}
           <p class="text-small text-grey-dk-000 mb-0">
-            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
+            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if site.gh_edit_collections_dir %}/{{ site.gh_edit_collections_dir }}{% elsif page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
           </p>
         {% endif %}
       </div>


### PR DESCRIPTION
Hello everyone! I made this PR to enhance existing feature: _"Edit this page on GitHub" link text on footer_.

In this pr, `gh_edit_collections_dir` key is added on the _config.yml.   Users will be able to configure `gh_edit_collections_dir` to customize url of the "Edit this page on GitHub".

Leaving this value empty will make the gh_edit feature behaves same as before, therefore no worries for backward compatibility :)

I believe that this feature will be useful for those who use nested repository to store documents in a seperated github repository, like I do:

<img width="913" alt="image" src="https://user-images.githubusercontent.com/19310326/216891927-d61f18f7-afc8-4f45-b32c-c864fca1077c.png">
