### PR TITLE
Add CI for `github-pages` gem builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,21 @@ jobs:
     - name: Build Site
       run: bundle exec jekyll build
 
+  github-pages-build:
+    name: Build (github-pages gem)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1' # Not needed with a .ruby-version file
+        bundler-cache: false
+    - name: Bundle Install
+      run: BUNDLE_GEMFILE=fixtures/Gemfile-github-pages bundle install
+    - name: Build Site
+      run: BUNDLE_GEMFILE=fixtures/Gemfile-github-pages bundle exec jekyll build
+
   assets:
     name: Test CSS and JS
     runs-on: ubuntu-latest

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ exclude:
    - package-lock.json
    - Rakefile
    - README.md
+ # theme test code
+   - fixtures/
 
 # Set a path/url to a logo that will be displayed instead of the title
 #logo: "/assets/images/just-the-docs.png"

--- a/fixtures/Gemfile-github-pages
+++ b/fixtures/Gemfile-github-pages
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'github-pages', group: :jekyll_plugins

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,3 @@
+# Test Fixtures
+
+These files are used by Just the Docs maintainers to test *the theme itself*. **If you are using Just the Docs as a theme, you should not copy these files over.**


### PR DESCRIPTION
This is a small PR that:

- adds a `fixtures/Gemfile-github-pages`, the minimum gemfile necessary to build the site
- adds a new Actions workflow to build the site with that gemfile

In the future, this should prevent issues like #1074, where we push a change that passes the `jekyll` CI but fails to build on `github-pages` (and its dependencies - which in this case, was an older version of ruby sass).

(to be honest - not super happy with the code duplication, but I also think we'll have different build matrices for the different versions, so I'm fine with this for now)

Part of (but does not close) #1145.