### PR TITLE
Add to CI matrix: windows, macOS; Ruby 2.7; allow later versions of `bundler`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ name: CI
 
 jobs:
   jekyll-build:
-    name: Build Jekyll site
+    name: Build (jekyll gem)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,25 @@ on:
   pull_request:
     branches:
       - main
-      - 'v**'
 
 name: CI
 
 jobs:
   jekyll-build:
     name: Build Jekyll site
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         jekyll-version: [3.9, 4.3]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        ruby-version: [2.7, 3.1]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - name: Setup Ruby
+    - name: Setup Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1' # Not needed with a .ruby-version file
+        ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: false
     - name: Bundle Install
       run: bundle install
@@ -40,7 +42,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1' # Not needed with a .ruby-version file
+        ruby-version: '3.1'
         bundler-cache: false
     - name: Bundle Install
       run: BUNDLE_GEMFILE=fixtures/Gemfile-github-pages bundle install

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z ':!:*.jpg' ':!:*.png'`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
   spec.executables   << 'just-the-docs'
 
-  spec.add_development_dependency "bundler", "~> 2.3.5"
+  spec.add_development_dependency "bundler", ">= 2.3.5"
   spec.add_runtime_dependency "jekyll", ">= 3.8.5"
   spec.add_runtime_dependency "jekyll-seo-tag", ">= 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1"


### PR DESCRIPTION
This PR:

- matricizes (?) the OS parameter: we now also test on `windows` and `macOS`
- matricizes the Ruby version parameter: we now also test on Ruby 2.7
- loosens the `.gemspec` requirement for `bundler` to allow things greater than `2.3.5`
    - interestingly, this is because the Ruby 2.7 container has a **later** version of bundler than the 3.1 one!

The last point makes this user-facing, and thus I'll trigger a release for this PR sometime soon.

These only apply to the `jekyll-build` job. Here, I think we have a broader obligation to support various use-cases (maybe they're deploying on GitLab, generating files locally, etc.); in contrast, the `github-pages` gem is used exclusively for deploying to GitHub Pages, so we should try to match that environment exactly.

This PR closes #1145.