### PR TITLE
Add Percy for visual regression testing

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,0 +1,42 @@
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+name: Percy
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jekyll-version: [4.3]
+        ruby-version: [3.1]
+        node-version: [18.x]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: false
+    - name: Bundle Install
+      run: bundle install
+    - name: Install Jekyll ${{ matrix.jekyll-version }}
+      run: gem install jekyll -v ${{ matrix.jekyll-version }}
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - name: Init Search
+      run: bundle exec rake search:init
+    - name: Run Snapshot
+      run: npm run snapshot
+      env:
+        PERCY_TOKEN: "${{secrets.PERCY_TOKEN}}"

--- a/.percy.js
+++ b/.percy.js
@@ -2,6 +2,7 @@
 module.exports = {
   version: 2,
   static: {
-    include: ["docs/**/*.html", "404.html", "index.html"],
+    // include: ["docs/**/*.html", "404.html", "index.html"],
+    include: ["/docs/index-test/index.html"],
   },
 }

--- a/.percy.js
+++ b/.percy.js
@@ -1,0 +1,7 @@
+// .percy.js
+module.exports = {
+  version: 2,
+  static: {
+    include: ["docs/**/*.html", "404.html", "index.html"],
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
+        "@percy/cli": "^1.19.2",
         "prettier": "^2.8.4",
         "stylelint": "^14.16.1",
         "stylelint-config-prettier-scss": "0.0.1",
@@ -103,11 +104,246 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@percy/cli": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.19.2.tgz",
+      "integrity": "sha512-mHn+/MJBGWuSAu2fsIvvUJf/h6qzGXIwlZq6kVbUJl5Qwh4CPESeTRIGG8MKqJbQX+79vn8w4tdiIDHpPQ7HkQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-app": "1.19.2",
+        "@percy/cli-build": "1.19.2",
+        "@percy/cli-command": "1.19.2",
+        "@percy/cli-config": "1.19.2",
+        "@percy/cli-exec": "1.19.2",
+        "@percy/cli-snapshot": "1.19.2",
+        "@percy/cli-upload": "1.19.2",
+        "@percy/client": "1.19.2",
+        "@percy/logger": "1.19.2"
+      },
+      "bin": {
+        "percy": "bin/run.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-app": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.19.2.tgz",
+      "integrity": "sha512-VSXRT7HLMoLFANFN8GNJaAvApC6eIt4uDU+XI3xnPAdYpfA/YoRf4IamqQeIlggnul6BPFtkkk5QX+cNR2J5og==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.19.2",
+        "@percy/cli-exec": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-build": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.19.2.tgz",
+      "integrity": "sha512-JrNoWskp08gwSIVQ1HEpILVyTE9LLp1CqKNUHpvLd9t/BT1mHBj53rgPw/EV10c2TlNE/cCh5JkZnEtuxiQqCA==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-command": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.19.2.tgz",
+      "integrity": "sha512-UK3/uCUtt7ddKufXNyS7SBA06HClSl89TLJFZ1MOmvuqZJFBKzjaoHxEJ+FpAfiWwtcB7Z2BDizm0526wUxR8g==",
+      "dev": true,
+      "dependencies": {
+        "@percy/config": "1.19.2",
+        "@percy/core": "1.19.2",
+        "@percy/logger": "1.19.2"
+      },
+      "bin": {
+        "percy-cli-readme": "bin/readme.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-config": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.19.2.tgz",
+      "integrity": "sha512-UANzk3wJ3chLJwUQ1GBxu6wjm7goyy0qMkJ1xoOrAjuBL77b54h8NbR/vC6SgeRW2YbZZfHlWVCU8b9y3NE5FA==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-exec": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.19.2.tgz",
+      "integrity": "sha512-79W1dVgpimu5VVzpU+h6ex9x71S5cN3yZQ4Nm1IAbbIX+DPgZam12bTmTl3hXSE8624Z8+GCgbck4SdY3nJcDg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.19.2",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-exec/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@percy/cli-snapshot": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.19.2.tgz",
+      "integrity": "sha512-T21wBoFiF/we/bsYcxUFvbVpCtDI/K5K66p5h06dBdUNjwLAQvC08Ym21EDE1zi1Zr2+IQki/FRFhPlx6rf9/w==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.19.2",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-snapshot/node_modules/yaml": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@percy/cli-upload": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.19.2.tgz",
+      "integrity": "sha512-byISZAE79+DDyMhLEK7smjaLXenfJyieEWPAghrodcItBn3ua5ornjKzkquw5B1wErpI+qGjJBwRyz34FKOD4Q==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.19.2",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/client": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.19.2.tgz",
+      "integrity": "sha512-3uHkr1OU8sgSqNo1QiT3IsrHUdN2yOexRpPLqNnaX0JRu0G0OdPw/WgDz3fATbXfkuCXuoZjYCVTK1KeZXAqzA==",
+      "dev": true,
+      "dependencies": {
+        "@percy/env": "1.19.2",
+        "@percy/logger": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.19.2.tgz",
+      "integrity": "sha512-ZnArnLR2k1fA2Jx4xx8vfoILYUjMqnrEhvELucxQbzZGnYYfugXv0LL/EFlN9cnN+SoVbsMgHZO84TNu0/XE9A==",
+      "dev": true,
+      "dependencies": {
+        "@percy/logger": "1.19.2",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config/node_modules/yaml": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@percy/core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.19.2.tgz",
+      "integrity": "sha512-mluVlJUyOVhnZ1WxTYWG5dlUFyyWpWlMqyJEnthrrr+0Pqd4pDD++8gsYV0+CxXmofKtNRNOabfNGK0XLpybkw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@percy/client": "1.19.2",
+        "@percy/config": "1.19.2",
+        "@percy/dom": "1.19.2",
+        "@percy/logger": "1.19.2",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/dom": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.19.2.tgz",
+      "integrity": "sha512-U8tBcdy5HgYDChir/ow2YLgo7Ee2IcyRt7+JolUzVvI1GzSUyOjP73wPc8Qi1EH1MkrOPNrGSO4tdfiVr0h70A==",
+      "dev": true
+    },
+    "node_modules/@percy/env": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.19.2.tgz",
+      "integrity": "sha512-tM1zsD7jABkBDILqhcafb0UnLIsXQ5Saur7iXEsrAIRWjbx4I6ArUu+0CXu5EqJdXHwNFV2kLpt6ULU9gn+bIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/logger": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.19.2.tgz",
+      "integrity": "sha512-HD721muAG3fyB5kW/2XIZd+yy91VUb9c0PMc9M7D4nP0ikd7zbTOa4L+pX9bV5hN9OylrGmwXrKDSz++CEreCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
+      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -120,6 +356,16 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/ajv": {
       "version": "8.11.0",
@@ -219,6 +465,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -295,6 +550,18 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -309,6 +576,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-functions-list": {
@@ -398,6 +694,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -414,6 +719,26 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -460,6 +785,15 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -529,6 +863,21 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -675,6 +1024,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/import-fresh": {
@@ -977,6 +1341,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -1147,10 +1532,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -1161,6 +1561,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -1300,6 +1706,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1307,6 +1723,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -1511,6 +1936,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/semver": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -1524,6 +1969,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/signal-exit": {
@@ -2034,6 +2500,27 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -2056,6 +2543,16 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   },
@@ -2119,11 +2616,194 @@
         "fastq": "^1.6.0"
       }
     },
+    "@percy/cli": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.19.2.tgz",
+      "integrity": "sha512-mHn+/MJBGWuSAu2fsIvvUJf/h6qzGXIwlZq6kVbUJl5Qwh4CPESeTRIGG8MKqJbQX+79vn8w4tdiIDHpPQ7HkQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-app": "1.19.2",
+        "@percy/cli-build": "1.19.2",
+        "@percy/cli-command": "1.19.2",
+        "@percy/cli-config": "1.19.2",
+        "@percy/cli-exec": "1.19.2",
+        "@percy/cli-snapshot": "1.19.2",
+        "@percy/cli-upload": "1.19.2",
+        "@percy/client": "1.19.2",
+        "@percy/logger": "1.19.2"
+      }
+    },
+    "@percy/cli-app": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.19.2.tgz",
+      "integrity": "sha512-VSXRT7HLMoLFANFN8GNJaAvApC6eIt4uDU+XI3xnPAdYpfA/YoRf4IamqQeIlggnul6BPFtkkk5QX+cNR2J5og==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.19.2",
+        "@percy/cli-exec": "1.19.2"
+      }
+    },
+    "@percy/cli-build": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.19.2.tgz",
+      "integrity": "sha512-JrNoWskp08gwSIVQ1HEpILVyTE9LLp1CqKNUHpvLd9t/BT1mHBj53rgPw/EV10c2TlNE/cCh5JkZnEtuxiQqCA==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.19.2"
+      }
+    },
+    "@percy/cli-command": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.19.2.tgz",
+      "integrity": "sha512-UK3/uCUtt7ddKufXNyS7SBA06HClSl89TLJFZ1MOmvuqZJFBKzjaoHxEJ+FpAfiWwtcB7Z2BDizm0526wUxR8g==",
+      "dev": true,
+      "requires": {
+        "@percy/config": "1.19.2",
+        "@percy/core": "1.19.2",
+        "@percy/logger": "1.19.2"
+      }
+    },
+    "@percy/cli-config": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.19.2.tgz",
+      "integrity": "sha512-UANzk3wJ3chLJwUQ1GBxu6wjm7goyy0qMkJ1xoOrAjuBL77b54h8NbR/vC6SgeRW2YbZZfHlWVCU8b9y3NE5FA==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.19.2"
+      }
+    },
+    "@percy/cli-exec": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.19.2.tgz",
+      "integrity": "sha512-79W1dVgpimu5VVzpU+h6ex9x71S5cN3yZQ4Nm1IAbbIX+DPgZam12bTmTl3hXSE8624Z8+GCgbck4SdY3nJcDg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.19.2",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@percy/cli-snapshot": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.19.2.tgz",
+      "integrity": "sha512-T21wBoFiF/we/bsYcxUFvbVpCtDI/K5K66p5h06dBdUNjwLAQvC08Ym21EDE1zi1Zr2+IQki/FRFhPlx6rf9/w==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.19.2",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+          "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/cli-upload": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.19.2.tgz",
+      "integrity": "sha512-byISZAE79+DDyMhLEK7smjaLXenfJyieEWPAghrodcItBn3ua5ornjKzkquw5B1wErpI+qGjJBwRyz34FKOD4Q==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.19.2",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      }
+    },
+    "@percy/client": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.19.2.tgz",
+      "integrity": "sha512-3uHkr1OU8sgSqNo1QiT3IsrHUdN2yOexRpPLqNnaX0JRu0G0OdPw/WgDz3fATbXfkuCXuoZjYCVTK1KeZXAqzA==",
+      "dev": true,
+      "requires": {
+        "@percy/env": "1.19.2",
+        "@percy/logger": "1.19.2"
+      }
+    },
+    "@percy/config": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.19.2.tgz",
+      "integrity": "sha512-ZnArnLR2k1fA2Jx4xx8vfoILYUjMqnrEhvELucxQbzZGnYYfugXv0LL/EFlN9cnN+SoVbsMgHZO84TNu0/XE9A==",
+      "dev": true,
+      "requires": {
+        "@percy/logger": "1.19.2",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+          "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.19.2.tgz",
+      "integrity": "sha512-mluVlJUyOVhnZ1WxTYWG5dlUFyyWpWlMqyJEnthrrr+0Pqd4pDD++8gsYV0+CxXmofKtNRNOabfNGK0XLpybkw==",
+      "dev": true,
+      "requires": {
+        "@percy/client": "1.19.2",
+        "@percy/config": "1.19.2",
+        "@percy/dom": "1.19.2",
+        "@percy/logger": "1.19.2",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      }
+    },
+    "@percy/dom": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.19.2.tgz",
+      "integrity": "sha512-U8tBcdy5HgYDChir/ow2YLgo7Ee2IcyRt7+JolUzVvI1GzSUyOjP73wPc8Qi1EH1MkrOPNrGSO4tdfiVr0h70A==",
+      "dev": true
+    },
+    "@percy/env": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.19.2.tgz",
+      "integrity": "sha512-tM1zsD7jABkBDILqhcafb0UnLIsXQ5Saur7iXEsrAIRWjbx4I6ArUu+0CXu5EqJdXHwNFV2kLpt6ULU9gn+bIA==",
+      "dev": true
+    },
+    "@percy/logger": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.19.2.tgz",
+      "integrity": "sha512-HD721muAG3fyB5kW/2XIZd+yy91VUb9c0PMc9M7D4nP0ikd7zbTOa4L+pX9bV5hN9OylrGmwXrKDSz++CEreCA==",
+      "dev": true
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
+      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "dev": true,
+      "optional": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2136,6 +2816,16 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "ajv": {
       "version": "8.11.0",
@@ -2215,6 +2905,12 @@
         "fill-range": "^7.0.1"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2276,6 +2972,15 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
     "cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -2287,6 +2992,28 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "css-functions-list": {
@@ -2349,6 +3076,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2363,6 +3099,18 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -2402,6 +3150,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "file-entry-cache": {
@@ -2459,6 +3216,15 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.2.0",
@@ -2564,6 +3330,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
       "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
       "dev": true
+    },
+    "image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -2797,6 +3572,21 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -2919,16 +3709,34 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
     "picocolors": {
@@ -3011,11 +3819,30 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -3149,6 +3976,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
     "semver": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -3157,6 +3990,21 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.7",
@@ -3539,6 +4387,13 @@
         "signal-exit": "^3.0.7"
       }
     },
+    "ws": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "dev": true,
+      "requires": {}
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3556,6 +4411,16 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "bugs": "https://github.com/just-the-docs/just-the-docs/issues",
   "devDependencies": {
+    "@percy/cli": "^1.19.2",
     "prettier": "^2.8.4",
     "stylelint": "^14.16.1",
     "stylelint-config-prettier-scss": "0.0.1",
@@ -14,6 +15,7 @@
   },
   "scripts": {
     "test": "stylelint '**/*.scss'",
+    "snapshot": "bundle exec jekyll build && npx percy snapshot _site/ --base-url /just-the-docs",
     "format": "prettier --write '**/*.{scss,js,json}'",
     "stylelint-check": "stylelint-config-prettier-check"
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "stylelint '**/*.scss'",
-    "snapshot": "bundle exec jekyll build && npx percy snapshot _site/ --base-url /just-the-docs",
+    "snapshot": "bundle exec jekyll build --baseurl '' && npx percy snapshot _site/",
     "format": "prettier --write '**/*.{scss,js,json}'",
     "stylelint-check": "stylelint-config-prettier-check"
   }


### PR DESCRIPTION
This is a PR that adds the minimal scaffolding necessary to use [Percy](https://percy.io/) (which is now part of BrowserStack) for visual regression testing.

At the high level, what Percy does is take a screenshot of a page (e.g. our kitchen sink) and then diffs the screenshot against a known benchmark (e.g. our kitchen sink on `main`). The idea is that we'd trigger this on PRs so that we can catch changes across different browsers, viewports, etc.

Currently, Percy is checking for Chrome, Safari, Edge, and Firefox, on `375px` and `1280px` viewports. I'm only diffing our kitchen sink. Members of our Percy team can view the diff [on the builds page](https://percy.io/191da955/just-the-docs/builds/25243470?utm_campaign=191da955&utm_content=just-the-docs&utm_source=github_status_private).

Two hiccups:

- Percy's free plan has a limit of 5000 screenshots per month. Each snapshot of our site is counted as 8 screenshots (4 browsers * 2 widths), and I can't disable any of the browsers/widths.
    - in addition, we need to *also* generate a snapshot per push to `main` as the baseline snapshot
    - so, we have 625 snapshots / month (split into PRs and `main`); if we assume each PR will get about ~ 4 pushes, that limits us to 125 PRs a month (4 pushes + 1 from the new `main`)
    - I can also write some code to only trigger this action for changes that aren't just to the changelog, etc.
     - and, adding more files rate limits us further!
- unfortunately, the generated Percy page can only be viewed by members of the Just the Docs Percy team.
    - I'll invite all interested maintainers, but this is a bit of friction - especially for the author of the pull request

One other approach we could take is run this on every push to `main` (except CHANGELOG changes), and *only* run it on PRs that a maintainer manually triggers the workflow on! It adds another manual step, but can reduce the snapshot count.

What do we think? If we don't like this, I can easily uninstall the integration + delete the account. I'm not wedded to Percy; it just seemed like the easiest/most-supported platform after some googling. Hopefully, this (or another solution) makes it easier for us to review new code!

---

From a technical perspective, I spun up a new action that *just* uploads the snapshot (opposed to tacking it on an existing one). I've also added our project token as an environment variable. In the Checks section of this PR, you can click into `percy/just-the-docs` (with the limitation on auth discussed above).