### PR TITLE
Fix import order for `setup.scss`

### DIFF
--- a/_includes/css/just-the-docs.scss.liquid
+++ b/_includes/css/just-the-docs.scss.liquid
@@ -2,9 +2,9 @@
 $logo: "{{ site.logo | relative_url }}";
 {% endif %}
 @import "./support/support";
-@import "./custom/setup";
 @import "./color_schemes/light";
 @import "./color_schemes/{{ include.color_scheme }}";
+@import "./custom/setup";
 @import "./modules";
 {% include css/callouts.scss.liquid color_scheme = include.color_scheme %}
 {% include css/custom.scss.liquid %}


### PR DESCRIPTION
In the conversation for #1166, I noticed that the import order for `setup.scss` disagrees with our docs.

> In particular, the [docs for `setup.scss`](https://just-the-docs.com/docs/customization/#override-and-define-new-variables) reads:
> 
> > To define new SCSS variables, functions, or override existing theme variables, place SCSS code in `_sass/custom/setup.scss`
> 
> But, this is not true - `setup.scss` is loaded *before* all of the themes, so it doesn't override existing theme variables. 
> 
> In my opinion, the solution here is to move `setup.scss` after all the `color_scheme` SCSS. This way, `setup.scss` properly allows theme overrides. In addition, users who previously defined variables in `setup.scss` and then used them in their custom color schemes can shift those declarations to be entirely in the theme code.

This is a one-liner that fixes the behaviour to be in-line with what our docs state. 