### PR TITLE
Moves `.prettierrc` to `package.json`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "endOfLine": "lf",
-  "semi": false,
-  "singleQuote": false,
-  "tabWidth": 2,
-  "trailingComma": "es5"
-}

--- a/package.json
+++ b/package.json
@@ -35,5 +35,12 @@
       "no-descending-specificity": null,
       "scss/no-global-function-names": null
     }
+  },
+  "prettier": {
+    "endOfLine": "lf",
+    "semi": false,
+    "singleQuote": false,
+    "tabWidth": 2,
+    "trailingComma": "es5"
   }
 }


### PR DESCRIPTION
Short and sweet PR that does exactly what the title says. Note that this only affects developers of our theme, and is a no-op on the rest of the codebase (including formatting) -- it's just moving a config file!

The nice benefits: higher precedence, and one less file (that can confuse users who are forking this repo).