### PR TITLE
docs: exclude `CODE_OF_CONDUCT`, `docker-compose`, and `Dockerfile`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,9 @@ exclude:
    - package-lock.json
    - Rakefile
    - README.md
+   - CODE_OF_CONDUCT.md
+   - docker-compose.yml
+   - Dockerfile
  # theme test code
    - fixtures/
 


### PR DESCRIPTION
Noticed that these files are in our final `_site` build, and they shouldn't be! Bite-sized PR to exclude those.