### PR TITLE
Revert `mermaid_config.js` `prettier-ignore` comment

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ assets/js/search-data.json
 assets/js/zzzz-search-data.json
 assets/js/just-the-docs.js
 *.md
+_includes/mermaid_config.js

--- a/_includes/mermaid_config.js
+++ b/_includes/mermaid_config.js
@@ -1,2 +1,1 @@
-// prettier-ignore
 {}


### PR DESCRIPTION
I introduced a bug in #1172 --- there's an implicit requirement that the line in `mermaid_config.js` has either an expression or the start of a code block; a comment (and then a newline) is invalid.

(to maintain the ignore behaviour, I've instead moved it to the `.prettierignore`)

This one's on me -- I hadn't realized that the `prettier-ignore` affected this file. Given the relative urgency of this, going to merge this in.

Closes #1188.