### PR TITLE
Fix deprecation warning in Sass by replacing division operator with calc() function

### DIFF
--- a/_sass/support/_functions.scss
+++ b/_sass/support/_functions.scss
@@ -1,5 +1,5 @@
 @function rem($size, $unit: "") {
-  $rem-size: $size / $root-font-size;
+  $rem-size: calc($size / $root-font-size);
 
   @if $unit == false {
     @return #{$rem-size};


### PR DESCRIPTION
The change was made to fix the following Deprecation Warning 
![image](https://user-images.githubusercontent.com/43818888/224473808-9d47b635-54d0-4db9-9dda-a2ffa93ed9fd.png)
