### PR TITLE
Fix Deprecation Warning: Using / for division

### DIFF
--- a/_sass/support/_functions.scss
+++ b/_sass/support/_functions.scss
@@ -1,5 +1,5 @@
 @function rem($size, $unit: "") {
-  $rem-size: $size / $root-font-size;
+  $rem-size: calc($size / $root-font-size);
 
   @if $unit == false {
     @return #{$rem-size};


### PR DESCRIPTION
Fix Following Error: Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.