### PR TITLE
Fix code selection color issues

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -5,7 +5,9 @@
   box-sizing: border-box;
 }
 
-::selection {
+// intentionally does not override browser defaults for code blocks;
+// see: https://github.com/just-the-docs/just-the-docs/issues/1201
+*:not(code, code > span)::selection {
   color: $white;
   background: $link-color;
 }

--- a/_sass/vendor/OneLightJekyll/syntax.scss
+++ b/_sass/vendor/OneLightJekyll/syntax.scss
@@ -200,9 +200,6 @@ pre.highlight {
 .highlight .gi {
   color: #43d089;
 }
-.highlight ::selection {
-  background-color: #fff;
-}
 .highlight .language-json .w + .s2 {
   color: #e35549;
 }


### PR DESCRIPTION
This resolves an issue on Firefox where selecting a code block produces white text on a white background, which is not legible.

I did a bit more digging, and realized a handful of things:

- when I added the new `OneLightJekyll` theme, I inadvertently bundled in a `::selection` class; I've removed it.
    - I'm not really sure why this is a part of the theme in the first place!
    - this is technically the minimum change required to have no more issues
- however, at this point, Firefox now correctly uses the global `::selection`, which is white-on-purple; this is *different* from Chrome, which somehow overrides this for `pre` or `code`; I also (subjectively) think this is harder to read.
- the vast majority of websites default to the browser/user agent stylesheet for code highlighting; for example, [react.dev](https://react.dev)
- so, I've elected to instead default to the browser/user agent stylesheet; this has the nice side effect of making Chrome and Firefox consistent again

Questions for reviewers/community members:

- does this fix the problem for you? what about other browsers?
- do we like having the browser default for code selection, or should we stick to white-on-purple?

Closes #1201.