### PR TITLE
Disable copy code button in insecure contexts

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -491,39 +491,38 @@ jtd.onReady(function(){
   if (!window.isSecureContext) {
     console.log('Window does not have a secure context, therefore code clipboard copy functionality will not be available. For more details see https://web.dev/async-clipboard/#security-and-permissions');
     return;
-  } else {
+  } 
+  
+  var codeBlocks = document.querySelectorAll('div.highlighter-rouge, div.listingblock > div.content, figure.highlight');
 
-    var codeBlocks = document.querySelectorAll('div.highlighter-rouge, div.listingblock > div.content, figure.highlight');
+  // note: the SVG svg-copied and svg-copy is only loaded as a Jekyll include if site.enable_copy_code_button is true; see _includes/icons/icons.html
+  var svgCopied =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copied"></use></svg>';
+  var svgCopy =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copy"></use></svg>';
 
-    // note: the SVG svg-copied and svg-copy is only loaded as a Jekyll include if site.enable_copy_code_button is true; see _includes/icons/icons.html
-    var svgCopied =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copied"></use></svg>';
-    var svgCopy =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copy"></use></svg>';
+  codeBlocks.forEach(codeBlock => {
+    var copyButton = document.createElement('button');
+    var timeout = null;
+    copyButton.type = 'button';
+    copyButton.ariaLabel = 'Copy code to clipboard';
+    copyButton.innerHTML = svgCopy;
+    codeBlock.append(copyButton);
 
-    codeBlocks.forEach(codeBlock => {
-      var copyButton = document.createElement('button');
-      var timeout = null;
-      copyButton.type = 'button';
-      copyButton.ariaLabel = 'Copy code to clipboard';
-      copyButton.innerHTML = svgCopy;
-      codeBlock.append(copyButton);
+    copyButton.addEventListener('click', function () {
+      if(timeout === null) {
+        var code = (codeBlock.querySelector('pre:not(.lineno, .highlight)') || codeBlock.querySelector('code')).innerText;
+        window.navigator.clipboard.writeText(code);
 
-      copyButton.addEventListener('click', function () {
-        if(timeout === null) {
-          var code = (codeBlock.querySelector('pre:not(.lineno, .highlight)') || codeBlock.querySelector('code')).innerText;
-          window.navigator.clipboard.writeText(code);
+        copyButton.innerHTML = svgCopied;
 
-          copyButton.innerHTML = svgCopied;
+        var timeoutSetting = 4000;
 
-          var timeoutSetting = 4000;
-
-          timeout = setTimeout(function () {
-            copyButton.innerHTML = svgCopy;
-            timeout = null;
-          }, timeoutSetting);
-        }
-      });
+        timeout = setTimeout(function () {
+          copyButton.innerHTML = svgCopy;
+          timeout = null;
+        }, timeoutSetting);
+      }
     });
-  }
+  });
 
 });
 

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -488,36 +488,42 @@ jtd.onReady(function(){
 
 jtd.onReady(function(){
 
-  var codeBlocks = document.querySelectorAll('div.highlighter-rouge, div.listingblock > div.content, figure.highlight');
+  if (!window.isSecureContext) {
+    console.log('Window does not have a secure context, therefore code clipboard copy functionality will not be available. For more details see https://web.dev/async-clipboard/#security-and-permissions');
+    return;
+  } else {
 
-  // note: the SVG svg-copied and svg-copy is only loaded as a Jekyll include if site.enable_copy_code_button is true; see _includes/icons/icons.html
-  var svgCopied =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copied"></use></svg>';
-  var svgCopy =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copy"></use></svg>';
+    var codeBlocks = document.querySelectorAll('div.highlighter-rouge, div.listingblock > div.content, figure.highlight');
 
-  codeBlocks.forEach(codeBlock => {
-    var copyButton = document.createElement('button');
-    var timeout = null;
-    copyButton.type = 'button';
-    copyButton.ariaLabel = 'Copy code to clipboard';
-    copyButton.innerHTML = svgCopy;
-    codeBlock.append(copyButton);
+    // note: the SVG svg-copied and svg-copy is only loaded as a Jekyll include if site.enable_copy_code_button is true; see _includes/icons/icons.html
+    var svgCopied =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copied"></use></svg>';
+    var svgCopy =  '<svg viewBox="0 0 24 24" class="copy-icon"><use xlink:href="#svg-copy"></use></svg>';
 
-    copyButton.addEventListener('click', function () {
-      if(timeout === null) {
-        var code = (codeBlock.querySelector('pre:not(.lineno, .highlight)') || codeBlock.querySelector('code')).innerText;
-        window.navigator.clipboard.writeText(code);
+    codeBlocks.forEach(codeBlock => {
+      var copyButton = document.createElement('button');
+      var timeout = null;
+      copyButton.type = 'button';
+      copyButton.ariaLabel = 'Copy code to clipboard';
+      copyButton.innerHTML = svgCopy;
+      codeBlock.append(copyButton);
 
-        copyButton.innerHTML = svgCopied;
+      copyButton.addEventListener('click', function () {
+        if(timeout === null) {
+          var code = (codeBlock.querySelector('pre:not(.lineno, .highlight)') || codeBlock.querySelector('code')).innerText;
+          window.navigator.clipboard.writeText(code);
 
-        var timeoutSetting = 4000;
+          copyButton.innerHTML = svgCopied;
 
-        timeout = setTimeout(function () {
-          copyButton.innerHTML = svgCopy;
-          timeout = null;
-        }, timeoutSetting);
-      }
+          var timeoutSetting = 4000;
+
+          timeout = setTimeout(function () {
+            copyButton.innerHTML = svgCopy;
+            timeout = null;
+          }, timeoutSetting);
+        }
+      });
     });
-  });
+  }
 
 });
 


### PR DESCRIPTION
Implements point (2a) of https://github.com/just-the-docs/just-the-docs/issues/1202

## Secure context - behaviour unchanged

![image](https://user-images.githubusercontent.com/3671582/232823898-1b683b51-20ca-4e79-91cc-d543ae76aacd.png)

## Unsecure context - copy icon not shown and console message logged

![image](https://user-images.githubusercontent.com/3671582/232823972-94e2ef83-e526-4ca3-b16f-5f0f4243b50c.png)
