### PR TITLE
Add custom scheme combinations

### DIFF
--- a/_includes/css/just-the-docs.scss.liquid
+++ b/_includes/css/just-the-docs.scss.liquid
@@ -7,6 +7,11 @@ $logo: "{{ site.logo | relative_url }}";
 {% unless include.color_scheme == "light" %}
 @import "./color_schemes/{{ include.color_scheme }}";
 {% endunless %}
+{% if site.custom_schemes %}
+{% for scheme in site.custom_schemes %}
+@import "./custom_schemes/{{scheme}}";
+{% endfor %}
+{% endif %}
 @import "./modules";
 {% include css/callouts.scss.liquid color_scheme = include.color_scheme %}
 {% include css/custom.scss.liquid %}


### PR DESCRIPTION
Right now, this PR is just a sketch of the feature described in #483. It does work!

To test:

- first, run site as-is in the branch; observe that there are no errors (backwards-compatible)
- add a custom scheme
    - create a `custom_schemes` folder
    - place a file in it (ex `boop.scss`)
    - add an overriding style (ex `* { color: purple !important }`
    - in `_config.yml`, define `custom_schemes: ["boop"]`
    - reload `jekyll serve`
    - observe that the site is now purple :)
- add multiple schemes
    - rinse and repeat from above!

Things to still resolve:

- where in the import order should this go? went with the original suggestion in the issue
- documentation (if we like this implementation, I'll write some up)
- in the short term, do we want to restructure any of our scheme/theme code to use this new key? likely not, right?

Closes #483.