### PR TITLE
Change `media-feature-range-notation` to `prefix`

### DIFF
--- a/_sass/support/mixins/_layout.scss
+++ b/_sass/support/mixins/_layout.scss
@@ -12,7 +12,7 @@
   // If the key exists in the map
   @if $value {
     // Prints a media query based on the value
-    @media (width >= rem($value)) {
+    @media (min-width: rem($value)) {
       @content;
     }
   } @else {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       "alpha-value-notation": null,
       "at-rule-empty-line-before": null,
       "color-function-notation": null,
+      "media-feature-range-notation": "prefix",
       "no-descending-specificity": null,
       "scss/no-global-function-names": null
     }


### PR DESCRIPTION
Realized that the new syntax is only supported on [Safari 16.4](https://caniuse.com/css-media-range-syntax), which is gated by OS updates. Going to revert this change for the foreseeable future.

Closes #1239.