### PR TITLE
Fix CI installing multiple copies of Jekyll, explicitly add `kramdown-gfm-parser` to the `3.9` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,18 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: false
-    - name: Bundle Install
+    - name: Bundle Install (Jekyll ${{ matrix.jekyll-version }})
       run: bundle install
-    - name: Install Jekyll ${{ matrix.jekyll-version }}
-      run: gem install jekyll -v ${{ matrix.jekyll-version }}
+      env:
+        BUNDLE_GEMFILE: fixtures/Gemfile-jekyll-${{ matrix.jekyll-version }}
     - name: Init Search
       run: bundle exec rake search:init
+      env:
+        BUNDLE_GEMFILE: fixtures/Gemfile-jekyll-${{ matrix.jekyll-version }}
     - name: Build Site
       run: bundle exec jekyll build
+      env:
+        BUNDLE_GEMFILE: fixtures/Gemfile-jekyll-${{ matrix.jekyll-version }}
 
   github-pages-build:
     name: Build (github-pages gem)
@@ -45,9 +49,13 @@ jobs:
         ruby-version: '3.1'
         bundler-cache: false
     - name: Bundle Install
-      run: BUNDLE_GEMFILE=fixtures/Gemfile-github-pages bundle install
+      run: bundle install
+      env:
+        BUNDLE_GEMFILE: fixtures/Gemfile-github-pages
     - name: Build Site
-      run: BUNDLE_GEMFILE=fixtures/Gemfile-github-pages bundle exec jekyll build
+      run: bundle exec jekyll build
+      env:
+        BUNDLE_GEMFILE: fixtures/Gemfile-github-pages
 
   assets:
     name: Test CSS and JS

--- a/fixtures/Gemfile-jekyll-3.9
+++ b/fixtures/Gemfile-jekyll-3.9
@@ -7,6 +7,7 @@ gem "rake", ">= 12.3.1"
 
 # required for Jekyll 3
 gem "webrick", "~> 1.7"
+gem "kramdown-parser-gfm", '~> 1.1'
 
 # docs-only
 gem "jekyll-github-metadata", ">= 2.15"

--- a/fixtures/Gemfile-jekyll-3.9
+++ b/fixtures/Gemfile-jekyll-3.9
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.9"
+
+gem "jekyll-seo-tag", ">= 2.0"
+gem "rake", ">= 12.3.1"
+
+# required for Jekyll 3
+gem "webrick", "~> 1.7"
+
+# docs-only
+gem "jekyll-github-metadata", ">= 2.15"

--- a/fixtures/Gemfile-jekyll-4.3
+++ b/fixtures/Gemfile-jekyll-4.3
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+
+gem "jekyll-seo-tag", ">= 2.0"
+gem "rake", ">= 12.3.1"
+
+# docs-only
+gem "jekyll-github-metadata", ">= 2.15"


### PR DESCRIPTION
See: https://github.com/just-the-docs/just-the-docs/pull/1112#issuecomment-1533518323.