### PR TITLE
Specify `color-scheme` for `:root`

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -1,6 +1,10 @@
 // Base element style overrides
 // stylelint-disable selector-no-type, selector-max-type, selector-max-specificity, selector-max-id
 
+:root {
+  color-scheme: $color-scheme;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/_sass/color_schemes/dark.scss
+++ b/_sass/color_schemes/dark.scss
@@ -1,3 +1,4 @@
+$color-scheme: dark;
 $body-background-color: $grey-dk-300;
 $body-heading-color: $grey-lt-000;
 $body-text-color: $grey-lt-300;

--- a/_sass/color_schemes/light.scss
+++ b/_sass/color_schemes/light.scss
@@ -1,3 +1,4 @@
+$color-scheme: light !default;
 $body-background-color: $white !default;
 $body-heading-color: $grey-dk-300 !default;
 $body-text-color: $grey-dk-100 !default;


### PR DESCRIPTION
Previously, the color scheme information was not passed on to the browser. This could result in scrollbars being light, when the dark theme is in use.

Now, `:root { color-scheme: $color-scheme; }` is specified. This will ensure the color theme is enforced.

Ref: [color-scheme - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme)

Closes #1279

---

![Screenshot](https://github.com/just-the-docs/just-the-docs/assets/1391569/a9acc042-956c-4990-b573-6c32dcf39dae)