### PR TITLE
Add example of using <details> tag in Markdown kitchen sink

### DIFF
--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -310,6 +310,21 @@ graph TD;
     C-->D;
 ```
 
+### Details Dropdown
+
+The following uses the `<details>` tag to create a dropdown element.
+
+<details markdown="block" style="background-color:#2383ff17; padding: 20px;border-radius:10px">
+<summary><strong>Shopping list dropdown</strong></summary>
+
+This is content inside a dropdown.
+
+- [ ] Apples
+- [ ] Oranges
+- [ ] Milk
+
+</details>
+
 
 ```
 The final element.

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -310,22 +310,17 @@ graph TD;
     C-->D;
 ```
 
-### Details Dropdown
+### Collapsed Section
 
-The following uses the `<details>` tag to create a dropdown element.
+The following uses the [`<details>`](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections) tag to create a collapsed section.
 
-<details markdown="block" style="background-color:#2383ff17; padding: 20px;border-radius:10px">
-<summary><strong>Shopping list dropdown</strong></summary>
+<details markdown="block">
+<summary>Shopping list (click me!)</summary>
 
-This is content inside a dropdown.
+This is content inside a `<details>` dropdown.
 
 - [ ] Apples
 - [ ] Oranges
 - [ ] Milk
 
 </details>
-
-
-```
-The final element.
-```


### PR DESCRIPTION
I hope you will consider adding this example of how to use the `<details>` tag to the Markdown kitchen sink. I found the details in https://github.com/just-the-docs/just-the-docs/issues/246 solved a problem I was having, and adding this example would be a handy reference for the page.