### PR TITLE
Fix missing closing `</button>` tag in `sidebar.html`

### DIFF
--- a/_includes/components/sidebar.html
+++ b/_includes/components/sidebar.html
@@ -3,7 +3,7 @@
     <a href="{{ '/' | relative_url }}" class="site-title lh-tight">{% include title.html %}</a>
     <button id="menu-button" class="site-button btn-reset" aria-label="Toggle menu" aria-pressed="false">
       <svg viewBox="0 0 24 24" class="icon" aria-hidden="true"><use xlink:href="#svg-menu"></use></svg>
-    </a>
+    </button>
   </div>
   <nav aria-label="Main" id="site-nav" class="site-nav">
     {% assign pages_top_size = site.html_pages


### PR DESCRIPTION
Ref: https://github.com/just-the-docs/just-the-docs/pull/1259#issuecomment-1655899503.