### PR TITLE
ci: bump Ruby to `3.2`, changes core test matrix to `3.x`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         jekyll-version: [3.9, 4.3]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        ruby-version: [2.7, 3.1]
+        ruby-version: [3.0, 3.1, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: 3.2
         bundler-cache: false
     - name: Bundle Install
       run: bundle install
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.1]
+        ruby-version: [3.2]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         jekyll-version: [3.9, 4.3]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        ruby-version: [3.0, 3.1, 3.2]
+        ruby-version: ["3.0", "3.1", "3.2"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: "3.2"
         bundler-cache: false
     - name: Bundle Install
       run: bundle install
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.2]
+        ruby-version: ["3.2"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: 3.2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: "3.2"
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Ruby 3.2
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: "3.2"
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 3.1
+    - name: Set up Ruby 3.2
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.2
 
     - name: Publish to GPR
       run: |


### PR DESCRIPTION
Ruby 3.2 has stabilized (and the bug with Liquid has been patched). I think this is a good time for us to bump all of our versions, especially with the discussion in #1307.

Separately, I've:

- changed the core test matrix to be across `3.0`, `3.1`, and `3.2`. Ruby 2 has been EOL for ~ 4 months, while 3.0 is around for about 7 more months. 
- standardized the formatting of our CI ruby versions to be strings; this is because the number `3.0` gets YAML-casted to `3`