### PR TITLE
Fix JS error for pages excluded from navigation

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -76,7 +76,9 @@ function initNav() {
 // The page-specific stylesheet is assumed to have index 1 in the list of stylesheets.
 
 function disableHeadStyleSheet() {
-  document.styleSheets[1].disabled = true;
+  if (document.styleSheets[1]) {
+    document.styleSheets[1].disabled = true;
+  }
 }
 
 {%- if site.search_enabled != false %}


### PR DESCRIPTION
Fix #1331

Pages excluded from the navigation do not have a second (page-specific) stylesheet in the head. When JS is enabled, an error arises when such a page is loaded, due to `initNav()` trying to disable a non-existent stylesheet.

This PR stops JS trying to disable the second stylesheet when it doesn't exist.

Note that issue #1331 was reported in connection with optimising the build of the endoflife.date site by following [my suggestion](https://github.com/just-the-docs/just-the-docs/pull/1244#issuecomment-1660246728) in #1244, but the bug also appears on the theme website at https://just-the-docs.com/404.html.