### PR TITLE
Fix JS stylesheet disables interfering with user-defined stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ This website is built from the `HEAD` of the `main` branch of the theme reposito
 
 Code changes to `main` that are *not* in the latest release:
 
-- N/A
+- Fixed: JS stylesheet disables interfering with user-defined stylesheets by [@mattxwang] in [#1350]
+
+[#1350]: https://github.com/just-the-docs/just-the-docs/pull/1350
 
 ## Release v0.6.2
 

--- a/_includes/head_nav.html
+++ b/_includes/head_nav.html
@@ -4,7 +4,7 @@
   Results in: HTML for a page-specific style element.
   Includes:
     css/activation.scss.liquid.
-  Overwrites: 
+  Overwrites:
     activation, test_scss, scss, css, index, count.
   Should not be cached, because css/activation.scss.liquid depends on page.
 {%- endcomment -%}
@@ -42,7 +42,7 @@
 {%- unless count == 1 %}
 {%- assign index = 1 | minus: count -%}
 {%- assign css = scss | scssify | split: ".site-nav" | slice: index, count | join: ".site-nav" -%}
-<style type="text/css">
+<style type="text/css" id="jtd-theme-style-nav-activation">
 {{ css | prepend: ".site-nav" }}
 </style>
 {%- endunless %}

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -38,7 +38,7 @@ function initNav() {
   const siteNav = document.getElementById('site-nav');
   const mainHeader = document.getElementById('main-header');
   const menuButton = document.getElementById('menu-button');
-  
+
   disableHeadStyleSheet();
 
   jtd.addEvent(menuButton, 'click', function(e){
@@ -69,12 +69,12 @@ function initNav() {
 }
 
 // The page-specific <style> in the <head> is needed only when JS is disabled.
-// Moreover, it incorrectly overrides dynamic stylesheets set by setTheme(theme). 
-// The page-specific stylesheet is assumed to have index 1 in the list of stylesheets.
+// Moreover, it incorrectly overrides dynamic stylesheets set by setTheme(theme).
 
 function disableHeadStyleSheet() {
-  if (document.styleSheets[1]) {
-    document.styleSheets[1].disabled = true;
+  const activation = document.getElementById('jtd-theme-style-nav-activation');
+  if (activation) {
+    activation.disabled = true;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/just-the-docs/just-the-docs/pull/1335#pullrequestreview-1603158589, where I said:

> Though, the process of testing this has raised a different question for me: let's say that the user has a page excluded from navigation *and* has added a custom `<style>` tag in `head_custom.html`. To my understanding, `head_nav.html` wouldn't add a `<style>` tag, and thus, the user's custom `<style>` tag is the second stylesheet; it'd then get disabled by `disableHeadStylesheet`. In this case, that would make `0.6.0` a regression, since we're accidentally disabling user stylesheets!

Leaving this as draft since:

- it seems like there are other changes going on in `fix-head-nav`
- there is some discussion on `<noscript>`, which I need to catch up on; ref: https://github.com/just-the-docs/just-the-docs/pull/1086#issuecomment-1710577573
- I should revisit this when I have more sleep!
