### PR TITLE
Remove href from the navigation link to the current page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Code changes to `main` that are *not* in the latest release:
 
 ### Bugfixes
 
-- Fixed: Remove href from the navigation link to the current page by [@pdmosses] in [#1356]
+- Fixed: remove href from the navigation link to the current page by [@pdmosses] in [#1356]
 
 [#1356]: https://github.com/just-the-docs/just-the-docs/pull/1356
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ This website is built from the `HEAD` of the `main` branch of the theme reposito
 
 Code changes to `main` that are *not* in the latest release:
 
-- N/A
+### Bugfixes
+
+- Fixed: Remove href from the navigation link to the current page by [@pdmosses] in [#1356]
+
+[#1356]: https://github.com/just-the-docs/just-the-docs/pull/1356
 
 ## Release v0.6.2
 

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -501,6 +501,7 @@ function activateNav() {
   var target = navLink();
   if (target) {
     target.classList.toggle('active', true);
+    target.removeAttribute('href');
   }
   while (target) {
     while (target && !(target.classList && target.classList.contains('nav-list-item'))) {


### PR DESCRIPTION
The navigation link to the selected page is currently clickable. It appears that the only effect of clicking on it is to scroll to the top of the same page.

@williamsartijose2023 [suggested to make just the link to the home page non-clickable](https://github.com/just-the-docs/just-the-docs/discussions/1355#discussioncomment-7069062), but the same motivation presumably applies to all navigation links.

This PR uses JS to remove the `href` attribute from the link to the selected page. The [PR preview](https://deploy-preview-1356--just-the-docs.netlify.app/) shows the effect. The PR has no effect when JS is disabled in the browser.

> [!WARNING]
> This would be a breaking change.

Note: The navigation panel is _fixed_ (the HTML is page-independent) so it isn't possible to simply omit the `href` attribute for the link to the selected page when generating the links (which would avoid the need for JS).
