### PR TITLE
Fixes erroneous parentheses in `site_nav` conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Code changes to `main` that are *not* in the latest release:
 
 - Fixed: remove href from the navigation link to the current page by [@pdmosses] in [#1356]
 - Fixed: improve build time by [@pdmosses] in [#1358]
+- Fixed: erroneous parentheses in `site_nav` conditional by [@mattxwang] in [#1366]
 
 {: .warning }
 [#1358] moved `_includes/nav.html` to the `_includes/components` directory,
@@ -39,6 +40,7 @@ Users who were overriding that file will need to adjust their sites accordingly.
 [#1356]: https://github.com/just-the-docs/just-the-docs/pull/1356
 [#1358]: https://github.com/just-the-docs/just-the-docs/pull/1358
 [#1360]: https://github.com/just-the-docs/just-the-docs/pull/1360
+[#1366]: https://github.com/just-the-docs/just-the-docs/pull/1366
 
 ## Release v0.6.2
 

--- a/_includes/components/site_nav.html
+++ b/_includes/components/site_nav.html
@@ -23,7 +23,7 @@
       {%- for node in site.nav_external_links -%}
         <li class="nav-list-item external">
           <a href="{{ node.url | absolute_url }}" class="nav-list-link external"
-            {% if node.opens_in_new_tab or (node.opens_in_new_tab == nil and site.nav_external_links_new_tab) %}
+            {% if node.opens_in_new_tab or node.opens_in_new_tab == nil and site.nav_external_links_new_tab %}
               target="_blank" rel="noopener noreferrer"
             {% endif %}
           >


### PR DESCRIPTION
Ref: https://github.com/just-the-docs/just-the-docs/pull/1360#issuecomment-1751358990.

I'm sorry for not catching this earlier; I'm surprised that this slipped my mind (maybe I'm juggling too many templating languages).

Though, also, I'm surprised that this doesn't flag as a compiler error?