### PR TITLE
Fixed: navigation scroll to active link regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Code changes to `main` that are *not* in the latest release:
 - Fixed: remove href from the navigation link to the current page by [@pdmosses] in [#1356]
 - Fixed: improve build time by [@pdmosses] in [#1358]
 - Fixed: erroneous parentheses in `site_nav` conditional by [@mattxwang] in [#1366]
+- Fixed: navigation scroll to active link regression by [@pdmosses] in [#1367]
 
 {: .warning }
 [#1358] moved `_includes/nav.html` to the `_includes/components` directory,
@@ -41,6 +42,7 @@ Users who were overriding that file will need to adjust their sites accordingly.
 [#1358]: https://github.com/just-the-docs/just-the-docs/pull/1358
 [#1360]: https://github.com/just-the-docs/just-the-docs/pull/1360
 [#1366]: https://github.com/just-the-docs/just-the-docs/pull/1366
+[#1367]: https://github.com/just-the-docs/just-the-docs/pull/1367
 
 ## Release v0.6.2
 

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -497,6 +497,7 @@ function scrollNav() {
   if (targetLink) {
     const rect = targetLink.getBoundingClientRect();
     document.getElementById('site-nav').scrollBy(0, rect.top - 3*rect.height);
+    targetLink.removeAttribute('href');
   }
 }
 
@@ -507,7 +508,6 @@ function activateNav() {
   var target = navLink();
   if (target) {
     target.classList.toggle('active', true);
-    target.removeAttribute('href');
   }
   while (target) {
     while (target && !(target.classList && target.classList.contains('nav-list-item'))) {


### PR DESCRIPTION
This PR fixes a regression with the automatic scrolling of the navigation panel to ensure that the link to the current page is visible. The regression is due to #1356: see the [comments](https://github.com/just-the-docs/just-the-docs/pull/1356#issuecomment-1751483067) there.

The `href` with the URL of the current page is inspected by `navLink()`, so it should not be removed until after the calls of `navLink()` in `scrollNav()` and `activateNav()`.

As `scrollNav()` follows `activateNav()`, the removal of `href` needs to be left to `scrollNav()`.

### Testing

1. Browse the [deploy preview](https://deploy-preview-1367--just-the-docs.netlify.app/).
2. Increase the zoom level so that only part of the navigation panel is visible.
3. Click on the link to [Callouts](https://deploy-preview-1367--just-the-docs.netlify.app/docs/ui-components/callouts/) in the UI Components navigation.
4. Check that the link remains visible.
5. Check that no JS errors have occurred.
