### PR TITLE
Auto-updating copyright date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 0 1 1 *'  # Run at 12:00 AM 01/01 every year to update copyright date
 
 name: CI
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ name: Deploy Jekyll site to Pages
 on:
   push:
     branches: ["main"]
+  schedule:
+    - cron: '0 0 1 1 *'  # Run at 12:00 AM 01/01 every year to update copyright date
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/_config.yml
+++ b/_config.yml
@@ -123,7 +123,7 @@ nav_external_links:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
+# footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter

--- a/_config.yml
+++ b/_config.yml
@@ -123,7 +123,7 @@ nav_external_links:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-# footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
+footer_content: "Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,3 +1,6 @@
 {%- if site.footer_content -%}
   <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
 {%- endif -%}
+<p class="text-small text-grey-dk-100 mb-0">
+    Copyright &copy; 2017-{{ site.time | date: '%Y' }} Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
+</p>

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,6 +1,3 @@
 {%- if site.footer_content -%}
-  <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
+  <p class="text-small text-grey-dk-100 mb-0">Copyright &copy; 2017-{{ site.time | date: '%Y' }} {{ site.footer_content }}</p>
 {%- endif -%}
-<p class="text-small text-grey-dk-100 mb-0">
-    Copyright &copy; 2017-{{ site.time | date: '%Y' }} Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
-</p>


### PR DESCRIPTION
This is an attempt to address issue #1383.

This works by setting up a cron job for both the `deploy` and `CI` workflows that runs on Jan 1st @ 12:00 AM every year.

I changed `footer_custom.html` to include the templated year and slightly changed `footer_content` in `_config.yml` to pair with the custom footer. 