### PR TITLE
Fix Liquid filter typo in breadcrumb component (`strip` instead of `trim`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,19 @@ This website is built from the `HEAD` of the `main` branch of the theme reposito
 
 Code changes to `main` that are *not* in the latest release:
 
-- N/A
+- Fixed: Liquid filter typo in breadcrumb component (`strip` instead of `trim`) by [@Zarthus] in [#1434]
 
 Docs changes made since the latest release:
 
 - N/A
+
+### New Contributors
+
+- [@Zarthus] made their first contribution in [#1434]
+
+[@Zarthus]: https://github.com/Zarthus
+
+[#1434]: https://github.com/just-the-docs/just-the-docs/pull/1434
 
 ## Release v0.8.0
 

--- a/_includes/components/breadcrumbs.html
+++ b/_includes/components/breadcrumbs.html
@@ -56,7 +56,7 @@
   {%- for nav_split in nav_anchor_splits -%}
   {%- unless forloop.last -%}
 
-  {%- assign nav_split_next = nav_anchor_splits[forloop.index] | trim -%}
+  {%- assign nav_split_next = nav_anchor_splits[forloop.index] | strip -%}
 
   {%- assign nav_split_test =
         nav_split_next | remove_first: nav_list_simple | prepend: nav_list_simple -%}


### PR DESCRIPTION
We are running into an issue upgrading from 0.7 to 0.8, suggesting that `trim` is not a method.

```
1.963   Liquid Exception: Liquid error (/usr/gem/gems/just-the-docs-0.8.0/_includes/components/breadcrumbs.html line 59): undefined filter trim included in /_layouts/default.html
1.968 /usr/gem/gems/liquid-4.0.4/lib/liquid/strainer.rb:58:in `invoke': Liquid error (/usr/gem/gems/just-the-docs-0.8.0/_includes/components/breadcrumbs.html line 59): undefined filter trim included  (Liquid::UndefinedFilter)
```
Looking at the liquid docs, we're probably looking for `strip` and not `trim`

https://shopify.github.io/liquid/filters/strip/

https://github.com/Shopify/liquid/blob/main/History.md#300--2014-11-12, I don't see a trim so it may have been an extension? This does work normally on just-the-docs itself running from scratch, so it might also be a bug in our application (or combination of different versions in plugins).