### PR TITLE
Build docs site using strict mode and `strict_filters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Code changes to `main` that are *not* in the latest release:
 
 Docs changes made since the latest release:
 
-- N/A
+- Build docs site using strict mode and `strict_filters` by [@Zarthus] in [#1435]
 
 ### New Contributors
 
@@ -30,6 +30,7 @@ Docs changes made since the latest release:
 [@Zarthus]: https://github.com/Zarthus
 
 [#1434]: https://github.com/just-the-docs/just-the-docs/pull/1434
+[#1435]: https://github.com/just-the-docs/just-the-docs/pull/1435
 
 ## Release v0.8.0
 

--- a/_config.yml
+++ b/_config.yml
@@ -120,7 +120,6 @@ nav_external_links:
 
 liquid:
    error_mode: strict
-   #strict_variables: true
    strict_filters: true
    
 # Footer content

--- a/_config.yml
+++ b/_config.yml
@@ -118,6 +118,11 @@ nav_external_links:
   - title: Just the Docs on GitHub
     url: https://github.com/just-the-docs/just-the-docs
 
+liquid:
+   error_mode: strict
+   #strict_variables: true
+   strict_filters: true
+   
 # Footer content
 # appears at the bottom of every page's main content
 


### PR DESCRIPTION
As per https://github.com/just-the-docs/just-the-docs/pull/1434#issuecomment-1981666074, this MR depends on the linked bugfix and needs rebasing before the CI will be green.