### PR TITLE
adding image path for children toc

### DIFF
--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -28,6 +28,7 @@
 {% for child in sorted_pages %}
   <li>
     <a href="{{ child.url | relative_url }}">{{ child.title }}</a>{% if child.summary %} - {{ child.summary }}{% endif %}
+        {% if child.image %}<br><a href="{{ child.url | relative_url }}"><img src="{{ child.image }}" width="200"></a>{% endif %}
   </li>
 {% endfor %}
 </ul>

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -182,6 +182,13 @@ has_toc: false
 
 ```
 
+#### Table of Contents (with images)
+If you'd like your table of contents for child documents to be displayed with image links, use the following [Font Matter](https://jekyllrb.com/docs/front-matter/) to define the image path.
+
+```yaml
+image: ../../assets/images/<your-image.jpg>
+```
+
 ### Children with children
 
 {: .text-gamma }


### PR DESCRIPTION
I'm toying around with customizing `just-the-docs` to fit my desires for a custom site and wanted to have a more visually stimulating TOC for a series of child documents. As such, I modified the `children.nav.html` to include an image thumbnail if one is provided by the child document.