### PR TITLE
adds light dark toggle to nav footer

### DIFF
--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,0 +1,31 @@
+<button class="btn js-toggle-dark-mode">☾ dark</button>
+
+<script>
+    const btnToggle = document.querySelector('.js-toggle-dark-mode');
+
+    if (localStorage.getItem('theme') === 'dark') {
+        jtd.setTheme('dark');
+        btnToggle.textContent = '☼ light';
+    } else {
+        jtd.setTheme('light');
+        btnToggle.textContent = '☾ dark';
+    }
+</script>
+
+<script>
+    const toggleDarkMode = document.querySelector('.js-toggle-dark-mode');
+
+    jtd.addEvent(toggleDarkMode, 'click', function () {
+        if (jtd.getTheme() === 'dark') {
+            jtd.setTheme('light');
+            toggleDarkMode.textContent = '☾ dark';
+            localStorage.setItem('theme', 'light');
+        } else {
+            jtd.setTheme('dark');
+            toggleDarkMode.textContent = '☼ light';
+            localStorage.setItem('theme', 'dark');
+        }
+    });
+</script>
+
+</br>


### PR DESCRIPTION
Added new `nav_footer_custom.html` to include a toggle button for changing site between light and dark mode. This also saves the toggle in `localStorage` so it doesn't change back on each new page load. I went with the nav footer since it seems to render well on mobile just below the site title (this was listed as a shortcoming in #1223).

I'm open to suggestions on where this should live as it living in the custom footer probably isn't the best long term choice.
