### PR TITLE
Fix: Protect theme JS file from front matter default for layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ This website is built from the `HEAD` of the `main` branch of the theme reposito
 
 Code changes to `main` that are *not* in the latest release:
 
-- N/A
+- Fixed: Protect theme JS file from front matter default for layout by [@pdmosses] in [#1447]
 
 Docs changes made since the latest release:
 
 - N/A
+
+[#1447]: https://github.com/just-the-docs/just-the-docs/pull/1447
 
 ## Release v0.8.1
 

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -1,4 +1,5 @@
 ---
+layout: null
 ---
 (function (jtd, undefined) {
 


### PR DESCRIPTION
Fix #1445

Front matter defaults with unrestricted `scope` (`path: ""`) can affect theme code files. [Jekyll](https://jekyllrb.com/docs/front-matter/#predefined-global-variables) supports using `null` to "produce a file without using a layout file".

This PR adds `layout: null` to `just-the-docs.js`, to avoid this file being affected by the following front matter defaults:

```yaml
defaults:
  -
    scope:
      path: ""
    values:
      layout: "default"
```

### Testing

1. Clone and build the theme docs locally.
2. Add the above front matter defaults to `_config.yml` and rebuild.
3. Check that `_site/assets/js/just-the-docs.js` has been affected by insertion of the default layout.
4. Repeat steps 1 and 2 with this PR branch.
5. Check that `_site/assets/js/just-the-docs.js` has not been affected.
