### PR TITLE
Fix: protect `search-data.json` file from front matter default for layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ This website is built from the `HEAD` of the `main` branch of the theme reposito
 Code changes to `main` that are *not* in the latest release:
 
 - Added: `nav_enabled` site, layout, and page-level variable to selectively show or hide the side/mobile menu by [@kevinlin1] in [#1441]. The minimal layout was reimplemented using this feature, and now has support for the site-wide search bar and auxiliary links.
+- Fixed: protect `search-data.json` file from front matter default for layout by [@mattxwang] in [#1468]
 
 Docs changes made since the latest release:
 
 - Docs: Explained the `nav_enabled` variables as an alternative to using the minimal layout [@kevinlin1] in [#1441].
+
+[#1468]: https://github.com/just-the-docs/just-the-docs/pull/1468
 
 ## Release v0.8.2
 

--- a/assets/js/zzzz-search-data.json
+++ b/assets/js/zzzz-search-data.json
@@ -1,4 +1,5 @@
 ---
+layout: null
 permalink: /assets/js/search-data.json
 ---
 {

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -9,6 +9,7 @@ namespace :search do
 
     File.open('assets/js/zzzz-search-data.json', 'w') do |f|
       f.puts '---
+layout: null
 permalink: /assets/js/search-data.json
 ---
 {


### PR DESCRIPTION
Fixes #1466. Prior art: #1447. Otherwise self-explanatory.

To test:

1. First, clone [template repository](https://github.com/just-the-docs/just-the-docs-template/tree/main). Observe that search works.
2. Next, add a default layout to all files
```yml
defaults:
  - scope:
      path: ""
    values:
      layout: "default"
```
3. Observe that search no longer works.
4. Apply this patch
5. Observe that search works again!