### PR TITLE
Apply Stylelint to `vendor/` code, fix errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Code changes to `main` that are *not* in the latest release:
 - Added: `nav_enabled` site, layout, and page-level variable to selectively show or hide the side/mobile menu by [@kevinlin1] in [#1441]. The minimal layout was reimplemented using this feature, and now has support for the site-wide search bar and auxiliary links.
 - Fixed: protect `search-data.json` file from front matter default for layout by [@mattxwang] in [#1468]
 - Fixed: Sass mixed declarations by [@bobvandevijver] in [#1495]
+- Fixed: redundant `monospace` in `pre`, `code`, `kbd`, `samp` reset by [@mattxwang] in [#1508]
 
 Docs changes made since the latest release:
 
@@ -29,6 +30,7 @@ Docs changes made since the latest release:
 
 [#1468]: https://github.com/just-the-docs/just-the-docs/pull/1468
 [#1495]: https://github.com/just-the-docs/just-the-docs/pull/1495
+[#1508]: https://github.com/just-the-docs/just-the-docs/pull/1508
 
 ## Release v0.8.2
 

--- a/_sass/vendor/OneDarkJekyll/syntax.scss
+++ b/_sass/vendor/OneDarkJekyll/syntax.scss
@@ -5,198 +5,261 @@ pre.highlight {
   background: #31343f;
   color: #dee2f7;
 }
+
 .highlight pre {
   background: #31343f;
 }
+
 .highlight .hll {
   background: #31343f;
 }
+
 .highlight .c {
   color: #63677e;
   font-style: italic;
 }
+
 .highlight .err {
   color: #960050;
   background-color: #1e0010;
 }
+
 .highlight .k {
   color: #e19ef5;
 }
+
 .highlight .l {
   color: #a3eea0;
 }
+
 .highlight .n {
   color: #dee2f7;
 }
+
 .highlight .o {
   color: #dee2f7;
 }
+
 .highlight .p {
   color: #dee2f7;
 }
+
 .highlight .cm {
   color: #63677e;
   font-style: italic;
 }
+
 .highlight .cp {
   color: #63677e;
   font-style: italic;
 }
+
 .highlight .c1 {
   color: #63677e;
   font-style: italic;
 }
+
 .highlight .cs {
   color: #63677e;
   font-style: italic;
 }
+
 .highlight .ge {
   font-style: italic;
 }
+
 .highlight .gs {
   font-weight: 700;
 }
+
 .highlight .kc {
   color: #e19ef5;
 }
+
 .highlight .kd {
   color: #e19ef5;
 }
+
 .highlight .kn {
   color: #e19ef5;
 }
+
 .highlight .kp {
   color: #e19ef5;
 }
+
 .highlight .kr {
   color: #e19ef5;
 }
+
 .highlight .kt {
   color: #e19ef5;
 }
+
 .highlight .ld {
   color: #a3eea0;
 }
+
 .highlight .m {
   color: #eddc96;
 }
+
 .highlight .s {
   color: #a3eea0;
 }
+
 .highlight .na {
   color: #eddc96;
 }
+
 .highlight .nb {
   color: #fdce68;
 }
+
 .highlight .nc {
   color: #fdce68;
 }
+
 .highlight .no {
   color: #fdce68;
 }
+
 .highlight .nd {
   color: #fdce68;
 }
+
 .highlight .ni {
   color: #fdce68;
 }
+
 .highlight .ne {
   color: #fdce68;
 }
+
 .highlight .nf {
   color: #dee2f7;
 }
+
 .highlight .nl {
   color: #fdce68;
 }
+
 .highlight .nn {
   color: #dee2f7;
 }
+
 .highlight .nx {
   color: #dee2f7;
 }
+
 .highlight .py {
   color: #fdce68;
 }
+
 .highlight .nt {
   color: #f9867b;
 }
+
 .highlight .nv {
   color: #fdce68;
 }
+
 .highlight .ow {
   font-weight: 700;
 }
+
 .highlight .w {
   color: #f8f8f2;
 }
+
 .highlight .mf {
   color: #eddc96;
 }
+
 .highlight .mh {
   color: #eddc96;
 }
+
 .highlight .mi {
   color: #eddc96;
 }
+
 .highlight .mo {
   color: #eddc96;
 }
+
 .highlight .sb {
   color: #a3eea0;
 }
+
 .highlight .sc {
   color: #a3eea0;
 }
+
 .highlight .sd {
   color: #a3eea0;
 }
+
 .highlight .s2 {
   color: #a3eea0;
 }
+
 .highlight .se {
   color: #a3eea0;
 }
+
 .highlight .sh {
   color: #a3eea0;
 }
+
 .highlight .si {
   color: #a3eea0;
 }
+
 .highlight .sx {
   color: #a3eea0;
 }
+
 .highlight .sr {
   color: #7be2f9;
 }
+
 .highlight .s1 {
   color: #a3eea0;
 }
+
 .highlight .ss {
   color: #7be2f9;
 }
+
 .highlight .bp {
   color: #fdce68;
 }
+
 .highlight .vc {
   color: #fdce68;
 }
+
 .highlight .vg {
   color: #fdce68;
 }
+
 .highlight .vi {
   color: #f9867b;
 }
+
 .highlight .il {
   color: #eddc96;
 }
+
 .highlight .gu {
   color: #75715e;
 }
+
 .highlight .gd {
   color: #f92672;
 }
+
 .highlight .gi {
   color: #a6e22e;
 }

--- a/_sass/vendor/OneLightJekyll/syntax.scss
+++ b/_sass/vendor/OneLightJekyll/syntax.scss
@@ -5,204 +5,269 @@ pre.highlight {
   background: #f9f9f9;
   color: #383942;
 }
+
 .highlight pre {
   background: #f9f9f9;
 }
+
 .highlight .hll {
   background: #f9f9f9;
 }
+
 .highlight .c {
   color: #9fa0a6;
   font-style: italic;
 }
+
 .highlight .err {
   color: #fff;
   background-color: #e05151;
 }
+
 .highlight .k {
   color: #a625a4;
 }
+
 .highlight .l {
   color: #50a04f;
 }
+
 .highlight .n {
   color: #383942;
 }
+
 .highlight .o {
   color: #383942;
 }
+
 .highlight .p {
   color: #383942;
 }
+
 .highlight .cm {
   color: #9fa0a6;
   font-style: italic;
 }
+
 .highlight .cp {
   color: #9fa0a6;
   font-style: italic;
 }
+
 .highlight .c1 {
   color: #9fa0a6;
   font-style: italic;
 }
+
 .highlight .cs {
   color: #9fa0a6;
   font-style: italic;
 }
+
 .highlight .ge {
   font-style: italic;
 }
+
 .highlight .gs {
   font-weight: 700;
 }
+
 .highlight .kc {
   color: #a625a4;
 }
+
 .highlight .kd {
   color: #a625a4;
 }
+
 .highlight .kn {
   color: #a625a4;
 }
+
 .highlight .kp {
   color: #a625a4;
 }
+
 .highlight .kr {
   color: #a625a4;
 }
+
 .highlight .kt {
   color: #a625a4;
 }
+
 .highlight .ld {
   color: #50a04f;
 }
+
 .highlight .m {
   color: #b66a00;
 }
+
 .highlight .s {
   color: #50a04f;
 }
+
 .highlight .na {
   color: #b66a00;
 }
+
 .highlight .nb {
   color: #ca7601;
 }
+
 .highlight .nc {
   color: #ca7601;
 }
+
 .highlight .no {
   color: #ca7601;
 }
+
 .highlight .nd {
   color: #ca7601;
 }
+
 .highlight .ni {
   color: #ca7601;
 }
+
 .highlight .ne {
   color: #ca7601;
 }
+
 .highlight .nf {
   color: #383942;
 }
+
 .highlight .nl {
   color: #ca7601;
 }
+
 .highlight .nn {
   color: #383942;
 }
+
 .highlight .nx {
   color: #383942;
 }
+
 .highlight .py {
   color: #ca7601;
 }
+
 .highlight .nt {
   color: #e35549;
 }
+
 .highlight .nv {
   color: #ca7601;
 }
+
 .highlight .ow {
   font-weight: 700;
 }
+
 .highlight .w {
   color: #f8f8f2;
 }
+
 .highlight .mf {
   color: #b66a00;
 }
+
 .highlight .mh {
   color: #b66a00;
 }
+
 .highlight .mi {
   color: #b66a00;
 }
+
 .highlight .mo {
   color: #b66a00;
 }
+
 .highlight .sb {
   color: #50a04f;
 }
+
 .highlight .sc {
   color: #50a04f;
 }
+
 .highlight .sd {
   color: #50a04f;
 }
+
 .highlight .s2 {
   color: #50a04f;
 }
+
 .highlight .se {
   color: #50a04f;
 }
+
 .highlight .sh {
   color: #50a04f;
 }
+
 .highlight .si {
   color: #50a04f;
 }
+
 .highlight .sx {
   color: #50a04f;
 }
+
 .highlight .sr {
   color: #0083bb;
 }
+
 .highlight .s1 {
   color: #50a04f;
 }
+
 .highlight .ss {
   color: #0083bb;
 }
+
 .highlight .bp {
   color: #ca7601;
 }
+
 .highlight .vc {
   color: #ca7601;
 }
+
 .highlight .vg {
   color: #ca7601;
 }
+
 .highlight .vi {
   color: #e35549;
 }
+
 .highlight .il {
   color: #b66a00;
 }
+
 .highlight .gu {
   color: #75715e;
 }
+
 .highlight .gd {
   color: #e05151;
 }
+
 .highlight .gi {
   color: #43d089;
 }
+
 .highlight .language-json .w + .s2 {
   color: #e35549;
 }
+
 .highlight .language-json .kc {
   color: #0083bb;
 }

--- a/_sass/vendor/normalize.scss/normalize.scss
+++ b/_sass/vendor/normalize.scss/normalize.scss
@@ -10,7 +10,7 @@
 
 html {
   line-height: 1.15; /* 1 */
-  -webkit-text-size-adjust: 100%; /* 2 */
+  text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections
@@ -62,7 +62,7 @@ hr {
  */
 
 pre {
-  font-family: monospace, monospace; /* 1 */
+  font-family: monospace; /* 1 */
   font-size: 1em; /* 2 */
 }
 
@@ -105,7 +105,7 @@ strong {
 code,
 kbd,
 samp {
-  font-family: monospace, monospace; /* 1 */
+  font-family: monospace; /* 1 */
   font-size: 1em; /* 2 */
 }
 
@@ -198,7 +198,7 @@ button,
 [type="button"],
 [type="reset"],
 [type="submit"] {
-  -webkit-appearance: button;
+  appearance: button;
 }
 
 /**
@@ -290,7 +290,7 @@ textarea {
  */
 
 [type="search"] {
-  -webkit-appearance: textfield; /* 1 */
+  appearance: textfield; /* 1 */
   outline-offset: -2px; /* 2 */
 }
 
@@ -299,7 +299,7 @@ textarea {
  */
 
 [type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
+  appearance: none;
 }
 
 /**
@@ -308,7 +308,7 @@ textarea {
  */
 
 ::-webkit-file-upload-button {
-  -webkit-appearance: button; /* 1 */
+  appearance: button; /* 1 */
   font: inherit; /* 2 */
 }
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "ignoreFiles": [
       "assets/css/just-the-docs-default.scss",
       "assets/css/just-the-docs-light.scss",
-      "assets/css/just-the-docs-dark.scss",
-      "_sass/vendor/**/*.scss"
+      "assets/css/just-the-docs-dark.scss"
     ],
     "extends": [
       "stylelint-config-standard-scss"


### PR DESCRIPTION
Changes are in three categories:

- whitespace
- devendoring prefixes for properties that have entered the CSS spec - reasonable to autofix
- removing a duplicate `monospace` in `monospace, monospace` `font-family` decl in normalize.scss - not autofix