### PR TITLE
Toggle + Auto Set Color scheme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -151,6 +151,8 @@ gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into t
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define
 color_scheme: nil
+# enable this to place buttons in the footer to toggle between light and dark mode
+enable_color_scheme_toggle: false
 
 callouts_level: quiet # or loud
 callouts:

--- a/_includes/components/sidebar.html
+++ b/_includes/components/sidebar.html
@@ -29,4 +29,10 @@
       This site uses <a href="https://github.com/just-the-docs/just-the-docs">Just the Docs</a>, a documentation theme for Jekyll.
     </footer>
   {% endif %}
+
+  {% if site.enable_color_scheme_toggle == 'true' %}
+    <div class="site-footer m-1">
+      {% include toggle-color-scheme.html %}
+    </div>
+  {% endif %}
 </div>

--- a/_includes/toggle-color-scheme.html
+++ b/_includes/toggle-color-scheme.html
@@ -1,0 +1,80 @@
+{% capture btn_aria_label %}
+  {%- if site.color_scheme == 'dark' -%}
+  Switch to Light Mode
+  {%- else -%}
+  Switch to Dark Mode
+  {%- endif -%}
+{% endcapture %}
+
+<span class="fs-3">
+  <button type="button"
+    class="btn js-toggle-dark-mode btn-outline"
+    style="margin-right: -3px; border-top-right-radius: 0; border-bottom-right-radius: 0;"
+    aria-label="{{ btn_aria_label }}">
+    {%- if site.color_scheme == 'dark' -%}
+    🔆 Light Mode
+    {%- else -%}
+    🌙 Dark Mode
+    {%- endif -%}
+  </button>
+  <button type="button"
+    class="btn js-unset-color-scheme btn-outline px-1"
+    style="margin-left: -3px; border-top-left-radius: 0; border-bottom-left-radius: 0;"
+    aria-label="Reset color scheme"
+    >⎌</button>
+</span>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    if (!jtd) { return; }
+
+    const toggleSchemeBtn = document.querySelector('.js-toggle-dark-mode');
+    const unsetColorScheme = document.querySelector('.js-unset-color-scheme');
+
+    // If the browser suggests a color scheme, and user hasn't saved/switch one yet..
+    if (window.matchMedia && !localStorage['jtd-theme']) {
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        jtd.setTheme('dark');
+        toggleSchemeBtn.textContent = '🔆 Light Mode';
+        toggleSchemeBtn.ariaLabel = 'Switch to Light Mode';
+      } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+        jtd.setTheme('light');
+        toggleSchemeBtn.textContent = '🌙 Dark Mode';
+        toggleSchemeBtn.ariaLabel = 'Switch to Dark Mode';
+      }
+    } else if (localStorage['jtd-theme']) {
+      jtd.setTheme(localStorage['jtd-theme']);
+    }
+
+    jtd.addEvent(toggleSchemeBtn, 'click', function() {
+      if (jtd.getTheme() === 'dark') {
+        localStorage['jtd-theme'] = 'light';
+        jtd.setTheme('light');
+        toggleSchemeBtn.textContent = '🌙 Dark Mode';
+        toggleSchemeBtn.ariaLabel = 'Switch to Dark Mode';
+      } else {
+        jtd.setTheme('dark');
+        localStorage['jtd-theme'] = 'dark';
+        toggleSchemeBtn.textContent = '🔆 Light Mode';
+        toggleSchemeBtn.ariaLabel = 'Switch to Light Mode';
+      }
+    });
+
+    // Add a way to unset the saved theme.
+    // "default" respect's the site config setting, but not the user browser pref
+    // So, check the pref and set the theme to the preferred one, if possible.
+    jtd.addEvent(unsetColorScheme, 'click', function() {
+      delete localStorage['jtd-theme'];
+
+      if (window.matchMedia) {
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          jtd.setTheme('dark');
+        } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+          jtd.setTheme('light');
+        }
+      } else {
+        jtd.setTheme('default');
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
This is inspired by lots of discussion, and I think addresses most of the concerns raised.

Adds a toggle button to the sidebar footer to switch between light and dark color schemes.

* When enabled, the "default" shown to the user is the system preference, and the toggle button is updated accordingly.
* If the user change the color scheme, their preference is saved in the local storage.
* The user can always reset to the system preference by clicking the "reset" button.

There's a few things to consider:
* Is it useful to separate switching scheme from respecting the system preference? Most comments seem to want both (And the code is already more complex than I'd like.)
* Should we separate out the HTML and JS into two files? This would allow easier customization of the HTML styling or for users to update the JS if they choose different color scheme names. (Not sure how common that is...)
* Definitely not sure of the best location for the buttons
* This uses a "button group" style, which doesn't exsit in JtD, so I've used inline styles. Hopefully this is a one off.
* There is no good icon I can think of for "reset", so I've used the Unicode "undo" ⎌
* IMO, a Bootstrap-style button dropdown with one item that says "Reset to system preference" would be more intuitive, but I'm not sure it's worth the extra complexity...
* Docs needed if this is useful. :)

See https://berkeley-cdss.github.io/berkeley-class-site/
for a live example.

<img width="435" alt="Screenshot 2024-08-15 at 2 40 56 AM" src="https://github.com/user-attachments/assets/4f735ed4-468e-4604-bd2e-5a283308d14f">

