### PR TITLE
docs: add sitemap (via `jekyll-sitemap` plugin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ Code changes to `main` that are *not* in the latest release:
 Docs changes made since the latest release:
 
 - Added: Allow unlimited multi-level navigation by [@pdmosses] in [#1440]
+- Added: sitemap (via `jekyll-sitemap` plugin) by [@mattxwang] in [#1530]
 
 [#1431]: https://github.com/just-the-docs/just-the-docs/pull/1431
 [#1440]: https://github.com/just-the-docs/just-the-docs/pull/1440
+[#1530]: https://github.com/just-the-docs/just-the-docs/pull/1530
 
 ## Release v0.9.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gemspec
 gem "jekyll-github-metadata", ">= 2.15"
 
 gem "jekyll-include-cache", group: :jekyll_plugins
+gem "jekyll-sitemap", group: :jekyll_plugins
 
 gem "html-proofer", "~> 5.0", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.7.2)
@@ -156,6 +158,7 @@ DEPENDENCIES
   html-proofer (~> 5.0)
   jekyll-github-metadata (>= 2.15)
   jekyll-include-cache
+  jekyll-sitemap
   just-the-docs!
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -22,40 +22,39 @@ repository: just-the-docs/just-the-docs # for github-metadata
 permalink: pretty
 
 defaults:
-  -
-    scope:
+  - scope:
       path: "docs" # an empty string here means all files in the project
       type: "pages"
     values:
       layout: "default"
 
 exclude:
- # from https://github.com/jekyll/jekyll/blob/master/lib/site_template/_config.yml:
-   - .sass-cache/
-   - .jekyll-cache/
-   - gemfiles/
-   - Gemfile
-   - Gemfile.lock
-   - node_modules/
-   - vendor/bundle/
-   - vendor/cache/
-   - vendor/gems/
-   - vendor/ruby/
- # specific to the theme website:
-   - bin/
-   - lib/
-   - "*.gemspec"
-   - "*.gem"
-   - LICENSE.txt
-   - package.json
-   - package-lock.json
-   - Rakefile
-   - README.md
-   - CODE_OF_CONDUCT.md
-   - docker-compose.yml
-   - Dockerfile
- # theme test code
-   - fixtures/
+  # from https://github.com/jekyll/jekyll/blob/master/lib/site_template/_config.yml:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  # specific to the theme website:
+  - bin/
+  - lib/
+  - "*.gemspec"
+  - "*.gem"
+  - LICENSE.txt
+  - package.json
+  - package-lock.json
+  - Rakefile
+  - README.md
+  - CODE_OF_CONDUCT.md
+  - docker-compose.yml
+  - Dockerfile
+  # theme test code
+  - fixtures/
 
 # Set a path/url to a logo that will be displayed instead of the title
 #logo: "/assets/images/just-the-docs.png"
@@ -87,7 +86,7 @@ search:
   # Supports true or false (default)
   button: false
   # Focus the search input by pressing `ctrl + focus_shortcut_key` (or `cmd + focus_shortcut_key` on macOS)
-  focus_shortcut_key: 'k'
+  focus_shortcut_key: "k"
 
 # For copy button on code
 enable_copy_code_button: true
@@ -134,8 +133,8 @@ nav_external_links:
 nav_error_report: true # default is false/nil.
 
 liquid:
-   error_mode: strict
-   strict_filters: true
+  error_mode: strict
+  strict_filters: true
 
 # Footer content
 # appears at the bottom of every page's main content
@@ -144,13 +143,11 @@ liquid:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt\">MIT license.</a> <a href=\"https://www.netlify.com/\">This site is powered by Netlify.</a>"
+footer_content: 'Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href="https://github.com/just-the-docs/just-the-docs/tree/main/LICENSE.txt">MIT license.</a> <a href="https://www.netlify.com/">This site is powered by Netlify.</a>'
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
-
-
 
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true # show or hide edit this page link
@@ -190,6 +187,7 @@ plugins:
   - jekyll-seo-tag
   - jekyll-github-metadata
   - jekyll-include-cache
+  - jekyll-sitemap
 
 kramdown:
   syntax_highlighter_opts:

--- a/fixtures/Gemfile-jekyll-3.9
+++ b/fixtures/Gemfile-jekyll-3.9
@@ -6,6 +6,7 @@ gem "jekyll-seo-tag", ">= 2.0"
 gem "rake", ">= 12.3.1"
 
 gem "jekyll-include-cache", group: :jekyll_plugins
+gem "jekyll-sitemap", group: :jekyll_plugins
 
 # required for Jekyll 3
 gem "webrick", "~> 1.7"

--- a/fixtures/Gemfile-jekyll-4.3
+++ b/fixtures/Gemfile-jekyll-4.3
@@ -6,6 +6,7 @@ gem "jekyll-seo-tag", ">= 2.0"
 gem "rake", ">= 12.3.1"
 
 gem "jekyll-include-cache", group: :jekyll_plugins
+gem "jekyll-sitemap", group: :jekyll_plugins
 
 # docs-only
 gem "jekyll-github-metadata", ">= 2.15"


### PR DESCRIPTION
Splitting this out of #1513 to make my life reviewing a bit easier! Note that this does *not* affect our downstream users, just the docs site for this project itself. 