### PR TITLE
Add `tabindex=0` to all code blocks

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -566,8 +566,17 @@ jtd.onReady(function(){
   {%- endif %}
 });
 
-// Copy button on code
+// Accessibility: set tabindex=0 on each code highlight block, so screenreaders
+// can focus over (particularly important if there's horizontal scroll)
+// see: https://dequeuniversity.com/rules/axe/4.9/scrollable-region-focusable?application=axeAPI
 
+jtd.onReady(() => {
+  document
+    .querySelectorAll("div.highlight")
+    .forEach(codeBlock => codeBlock.setAttribute("tabindex", "0"));
+});
+
+// Copy button on code
 
 {%- if site.enable_copy_code_button != false %}
 


### PR DESCRIPTION
This fixes an accessibility issue flagged by #1513; unlike #1531, which only affects our docs, this change actually affects all of our users (sow this warrants a bit of testing).

This is a bit hacky. Ideally, I'd like to do this at the markdown level, since this doesn't serve folks who have JS disabled (among many other things). But, we can't execute arbitrary ruby code for users on the pages gem.

Some things to investigate before merging:
- is there any way for me to deal with this using some rouge option? (seems like nothing in kramdown)
- how does this affect alternate syntax highlighters
- does using something like asciidoc break this?
- is this always the right thing to do accessibility-wise (and/or should I use a different selector)