### PR TITLE
Docs: Fix default-child wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ Code changes to `main` that are *not* in the latest release:
 
 Docs changes made since the latest release:
 
-- N/A
+- Fixed: incorrect docs for example with minimal layout parent, default layout child by [@janbrasna] in [#1540]
+
+[@janbrasna]: https://github.com/janbrasna
 
 [#1461]: https://github.com/just-the-docs/just-the-docs/pull/1461
+[#1540]: https://github.com/just-the-docs/just-the-docs/pull/1540
 [#1590]: https://github.com/just-the-docs/just-the-docs/pull/1590
 
 ## Release v0.10.0

--- a/docs/layout/minimal/default-child.md
+++ b/docs/layout/minimal/default-child.md
@@ -5,6 +5,6 @@ parent: A minimal layout page
 grand_parent: Layout
 ---
 
-# A minimal layout page
+# Default layout child page
 
-This is a child page that uses the same minimal layout as its parent page.
+This is a child page that uses the default layout as compared to its parent page (which demonstrates a minimal layout).

--- a/docs/layout/minimal/default-child.md
+++ b/docs/layout/minimal/default-child.md
@@ -7,4 +7,4 @@ grand_parent: Layout
 
 # Default layout child page
 
-This is a child page that uses the default layout as compared to its parent page (which demonstrates a minimal layout).
+This is a child page that uses the `default` layout as compared to its parent page (which uses the `minimal` layout).


### PR DESCRIPTION
There are two sub-pages demonstrating a difference in layouts used. However both share the same content. This makes them distinct.

https://just-the-docs.com/docs/layout/minimal/minimal/ :
- https://just-the-docs.com/docs/layout/minimal/default-child/
- https://just-the-docs.com/docs/layout/minimal/minimal-child/