### PR TITLE
Update in-page.md with more explicit directions for using {:toc}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ Code changes to `main` that are *not* in the latest release:
 Docs changes made since the latest release:
 
 - Fixed: incorrect docs for example with minimal layout parent, default layout child by [@janbrasna] in [#1540]
+- Fixed: unclear docs on using in-page table of contents by [@sebjameswml] in [#1551]
 
 [@janbrasna]: https://github.com/janbrasna
+[@sebjameswml]: https://github.com/sebjameswml
 
 [#1461]: https://github.com/just-the-docs/just-the-docs/pull/1461
 [#1540]: https://github.com/just-the-docs/just-the-docs/pull/1540
+[#1551]: https://github.com/just-the-docs/just-the-docs/pull/1551
 [#1590]: https://github.com/just-the-docs/just-the-docs/pull/1590
 
 ## Release v0.10.0

--- a/docs/navigation/in-page.md
+++ b/docs/navigation/in-page.md
@@ -19,6 +19,18 @@ To support in-page navigation, you can generate a *Table of Contents* (TOC) with
 
 To generate a *Table of Contents* in a page, you use Kramdown's `{:toc}` method, immediately after the start of a list. This will automatically generate a list of anchor links to various sections of the page, based on headings and heading levels.
 
+You simply write the lines
+```
+1. TOC
+{:toc}
+```
+in the markdown for your page wherever you want the table of contents to appear. The `{:toc}` line *must* follow the `1. TOC` line, which begins a list. If you prefer an un-numbered table of contents use:
+```
+- TOC
+{:toc}
+```
+instead.
+
 ## Omitting Heading from Table of Contents
 
 If you want to omit a particular heading from the TOC, follow it immediately by `{: .no_toc }` (possibly together with other CSS class names).
@@ -35,8 +47,6 @@ If you want to omit a particular heading from the TOC, follow it immediately by 
 ```
 
 This example omits the top-level heading (`In-Page Navigation`) from the TOC, as well as the heading for the *Table of Contents* itself.
-
-To get an unordered list, replace `1. TOC` by `- TOC` in the above example.
 
 ## Collapsible Table of Contents (with `<details>` and `<summary>`)
 

--- a/docs/navigation/in-page.md
+++ b/docs/navigation/in-page.md
@@ -19,17 +19,26 @@ To support in-page navigation, you can generate a *Table of Contents* (TOC) with
 
 To generate a *Table of Contents* in a page, you use Kramdown's `{:toc}` method, immediately after the start of a list. This will automatically generate a list of anchor links to various sections of the page, based on headings and heading levels.
 
-You simply write the lines
-```
+{: .note }
+`{:toc}` can be used only once on each page.
+
+You **must** have a list immediately preceding the table of contents. The type of list determines the style of your table of contents.
+
+For an *ordered* table of contents, use the following markdown code:
+
+```md
 1. TOC
 {:toc}
 ```
-in the markdown for your page wherever you want the table of contents to appear. The `{:toc}` line *must* follow the `1. TOC` line, which begins a list. If you prefer an un-numbered table of contents use:
+
+The `{:toc}` line *must* follow the `1. TOC` line, which begins a list.
+
+For an *unordered* table of contents, instead use the following markdown code:
+
 ```
 - TOC
 {:toc}
 ```
-instead.
 
 ## Omitting Heading from Table of Contents
 
@@ -64,9 +73,6 @@ You can make the Table of Contents collapsible using the `<details>` and `<summa
 ```
 
 The attribute `open` (which expands the Table of Contents by default) and the styling (here with `text-delta`) are optional.
-
-{: .note }
-`{:toc}` can be used only once on each page.
 
 ## Back to Top {#back-to-top-doc}
 


### PR DESCRIPTION
Fixes #1536.