### PR TITLE
Feature: Predefined alerts with customizable colors and headings 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem "jekyll-include-cache", group: :jekyll_plugins
 gem "jekyll-sitemap", group: :jekyll_plugins
 
 gem "html-proofer", "~> 5.0", :group => :development
+
+gem "sass-embedded", "1.78.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,19 +10,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (1.1.0)
+    Ascii85 (2.0.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)
-    async (2.11.0)
-      console (~> 1.25, >= 1.25.2)
+    async (2.21.1)
+      console (~> 1.29)
       fiber-annotation
-      io-event (~> 1.5, >= 1.5.1)
-      timers (~> 4.1)
-    bigdecimal (3.1.8)
+      io-event (~> 1.6, >= 1.6.5)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
-    console (1.25.2)
+    concurrent-ruby (1.3.5)
+    console (1.29.2)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -32,21 +31,23 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
-    faraday-net_http (3.1.0)
-      net-http
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
-    fiber-storage (0.1.0)
+    fiber-storage (1.0.0)
     forwardable-extended (2.6.0)
-    google-protobuf (4.28.2-arm64-darwin)
+    google-protobuf (4.29.3-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.28.2-x86_64-linux)
+    google-protobuf (4.29.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
     hashery (2.1.2)
@@ -60,9 +61,9 @@ GEM
       yell (~> 2.0)
       zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-event (1.5.1)
+    io-event (1.7.5)
     jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -92,42 +93,43 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.7.2)
-    kramdown (2.4.0)
-      rexml
+    json (2.9.1)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.5)
     mercenary (0.4.0)
-    net-http (0.4.1)
+    net-http (0.6.0)
       uri
-    nokogiri (1.16.5-arm64-darwin)
+    nokogiri (1.18.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pdf-reader (2.12.0)
-      Ascii85 (~> 1.0)
+    pdf-reader (2.13.0)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
     public_suffix (6.0.1)
-    racc (1.7.3)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
-    rouge (4.4.0)
+    rexml (3.4.0)
+    rouge (4.5.1)
     ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sass-embedded (1.78.0-arm64-darwin)
@@ -139,16 +141,15 @@ GEM
       faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    timers (4.3.5)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     unicode-display_width (2.6.0)
-    uri (0.13.0)
-    webrick (1.8.2)
+    uri (1.0.2)
+    webrick (1.9.1)
     yell (2.2.2)
-    zeitwerk (2.6.13)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin
@@ -161,6 +162,7 @@ DEPENDENCIES
   jekyll-include-cache
   jekyll-sitemap
   just-the-docs!
+  sass-embedded (= 1.78.0)
 
 BUNDLED WITH
    2.5.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,20 +10,19 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (1.1.0)
+    Ascii85 (2.0.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)
-    async (2.11.0)
-      console (~> 1.25, >= 1.25.2)
+    async (2.21.1)
+      console (~> 1.29)
       fiber-annotation
-      io-event (~> 1.5, >= 1.5.1)
-      timers (~> 4.1)
+      io-event (~> 1.6, >= 1.6.5)
     base64 (0.2.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
-    console (1.25.2)
+    concurrent-ruby (1.3.5)
+    console (1.29.2)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -34,16 +33,18 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
-    faraday-net_http (3.1.0)
-      net-http
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
-    fiber-storage (0.1.0)
+    fiber-storage (1.0.0)
     forwardable-extended (2.6.0)
     google-protobuf (4.29.3-arm64-darwin)
       bigdecimal
@@ -62,9 +63,9 @@ GEM
       yell (~> 2.0)
       zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-event (1.5.1)
+    io-event (1.7.5)
     jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -94,42 +95,43 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.7.2)
-    kramdown (2.4.0)
-      rexml
+    json (2.9.1)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.5)
     mercenary (0.4.0)
-    net-http (0.4.1)
+    net-http (0.6.0)
       uri
-    nokogiri (1.18.1-arm64-darwin)
+    nokogiri (1.18.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-linux-gnu)
+    nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pdf-reader (2.12.0)
-      Ascii85 (~> 1.0)
+    pdf-reader (2.13.0)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
     public_suffix (6.0.1)
-    racc (1.7.3)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
-    rouge (4.4.0)
+    rexml (3.4.0)
+    rouge (4.5.1)
     ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sass-embedded (1.78.0-arm64-darwin)
@@ -141,16 +143,15 @@ GEM
       faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    timers (4.3.5)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     unicode-display_width (2.6.0)
-    uri (0.13.0)
-    webrick (1.8.2)
+    uri (1.0.2)
+    webrick (1.9.1)
     yell (2.2.2)
-    zeitwerk (2.6.13)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin
@@ -165,6 +166,7 @@ DEPENDENCIES
   jekyll-include-cache
   jekyll-sitemap
   just-the-docs!
+  sass-embedded (= 1.78.0)
 
 BUNDLED WITH
    2.5.9

--- a/_sass/alerts.scss
+++ b/_sass/alerts.scss
@@ -18,9 +18,9 @@ $alert-color: $grey-dk-000;
   $alert-color: $grey-dk-000;
 }
 
-@include alert(NOTE,      $note-color,      "(i) " "Note");
-@include alert(TIP,       $tip-color,       "\$ " "Tip");
+@include alert(NOTE, $note-color, "(i) " "Note");
+@include alert(TIP, $tip-color, "\$ " "Tip");
 @include alert(IMPORTANT, $important-color, "!! " "Important");
-@include alert(WARNING,   $warning-color,   "/!\\ " "Warning");
-@include alert(CAUTION,   $caution-color,   "{!} " "Caution");
-@include alert(ALERT,     $alert-color);
+@include alert(WARNING, $warning-color, "/!\\ " "Warning");
+@include alert(CAUTION, $caution-color, "{!} " "Caution");
+@include alert(ALERT, $alert-color);

--- a/_sass/alerts.scss
+++ b/_sass/alerts.scss
@@ -1,0 +1,26 @@
+// Alerts
+
+// default color-scheme == light
+
+$note-color: $blue-100;
+$tip-color: $green-100;
+$important-color: $purple-200;
+$warning-color: $yellow-300;
+$caution-color: $red-300;
+$alert-color: $grey-dk-000;
+
+@if $color-scheme == dark {
+  $note-color: $blue-000;
+  $tip-color: $green-000;
+  $important-color: $purple-000;
+  $warning-color: $yellow-300;
+  $caution-color: $red-200;
+  $alert-color: $grey-dk-000;
+}
+
+@include alert(NOTE,      $note-color,      "(i) " "Note");
+@include alert(TIP,       $tip-color,       "\$ " "Tip");
+@include alert(IMPORTANT, $important-color, "!! " "Important");
+@include alert(WARNING,   $warning-color,   "/!\\ " "Warning");
+@include alert(CAUTION,   $caution-color,   "{!} " "Caution");
+@include alert(ALERT,     $alert-color);

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -6,7 +6,6 @@ $pink-000: #f77ef1;
 $pink-100: #f967f1;
 $pink-200: #e94ee1;
 $pink-300: #dd2cd4;
-
 $a-new-color: $pink-200;
 
 @if $color-scheme == dark {

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,1 +1,16 @@
 // custom SCSS (or CSS) goes here
+
+// The following is for use on the theme docs pages, and should not be included in the theme bundle.
+
+$pink-000: #f77ef1;
+$pink-100: #f967f1;
+$pink-200: #e94ee1;
+$pink-300: #dd2cd4;
+
+$a-new-color: $pink-200;
+
+@if $color-scheme == dark {
+  $a-new-color: $pink-000;
+}
+
+@include alert(NEW, $a-new-color, "🆕");

--- a/_sass/modules.scss
+++ b/_sass/modules.scss
@@ -15,3 +15,4 @@
 @import "./utilities/utilities";
 @import "./print";
 @import "./skiptomain";
+@import "./alerts";

--- a/_sass/support/mixins/_alerts.scss
+++ b/_sass/support/mixins/_alerts.scss
@@ -8,52 +8,53 @@
 
 @mixin alert($name, $color, $title: null) {
   blockquote.#{$name} {
-    border-left: .25rem solid $color;
-    padding-left: .8rem;
+    border-left: 0.25rem solid $color;
+    padding-left: 0.8rem;
     margin-left: 0;
     margin-right: 0;
-    
+
     > p:first-child {
       margin-top: 0;
     }
-      
+
     > p:last-child {
       margin-bottom: 0;
     }
 
     @if $title {
+      &::before {
+        color: $color;
+        content: $title;
+        display: block;
+        font-weight: bold;
+        padding-bottom: 0.125rem;
+      }
+    } @else {
+      > p:first-child {
+        margin-top: 0;
+        margin-bottom: 0;
+        color: $color;
+        display: block;
+        font-weight: bold;
+        padding-bottom: 0.125rem;
+      }
+
+      > p:nth-child(2) {
+        margin-top: 0;
+      }
+    }
+  }
+
+  p.#{$name} {
+    border-left: 0.25rem solid $color;
+    padding-left: 0.8rem;
+
     &::before {
       color: $color;
       content: $title;
       display: block;
       font-weight: bold;
-      padding-bottom: .125rem;
-    }
-    } @else {
-    > p:first-child {
-      margin-top: 0;
-      margin-bottom: 0;
-      color: $color;
-      display: block;
-      font-weight: bold;
-      padding-bottom: .125rem;
-    }
-    > p:nth-child(2) {
-      margin-top: 0;
-    }
-    }
-  }
-
-  p.#{$name} {
-    border-left: .25rem solid $color;
-    padding-left: .8rem;
-
-     &::before {
-      color: $color;
-      content: $title;
-      display: block;
-      font-weight: bold;
-      padding-bottom: .125rem;
+      padding-bottom: 0.125rem;
     }
   }
 }

--- a/_sass/support/mixins/_alerts.scss
+++ b/_sass/support/mixins/_alerts.scss
@@ -1,0 +1,59 @@
+// Alerts
+
+// An alert with a fixed title:
+// @include alert(IMPORTANT, $important-color, "!! " "Important");
+
+// An alert using the first paragraph of the blockquote as the title:
+// @include alert(ALERT, $alert-color);
+
+@mixin alert($name, $color, $title: null) {
+  blockquote.#{$name} {
+    border-left: .25rem solid $color;
+    padding-left: .8rem;
+    margin-left: 0;
+    margin-right: 0;
+    
+    > p:first-child {
+      margin-top: 0;
+    }
+      
+    > p:last-child {
+      margin-bottom: 0;
+    }
+
+    @if $title {
+    &::before {
+      color: $color;
+      content: $title;
+      display: block;
+      font-weight: bold;
+      padding-bottom: .125rem;
+    }
+    } @else {
+    > p:first-child {
+      margin-top: 0;
+      margin-bottom: 0;
+      color: $color;
+      display: block;
+      font-weight: bold;
+      padding-bottom: .125rem;
+    }
+    > p:nth-child(2) {
+      margin-top: 0;
+    }
+    }
+  }
+
+  p.#{$name} {
+    border-left: .25rem solid $color;
+    padding-left: .8rem;
+
+     &::before {
+      color: $color;
+      content: $title;
+      display: block;
+      font-weight: bold;
+      padding-bottom: .125rem;
+    }
+  }
+}

--- a/_sass/support/mixins/mixins.scss
+++ b/_sass/support/mixins/mixins.scss
@@ -1,3 +1,4 @@
 @import "./layout";
 @import "./buttons";
 @import "./typography";
+@import "./alerts";

--- a/docs/ui-components/alerts.md
+++ b/docs/ui-components/alerts.md
@@ -1,0 +1,219 @@
+---
+title: Alerts
+parent: UI Components
+nav_order: 7
+---
+
+# Alerts
+{: .no_toc }
+
+{: .ALERT }
+> *This feature has not yet been released!*
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+Markdown does not include support for alerts. However, GitHub has implemented five kinds of alerts: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION`. The [GitHub Docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) state:
+
+> Alerts are a Markdown extension based on the blockquote syntax that you can use to emphasize critical information. On GitHub, they are displayed with distinctive colors and icons to indicate the significance of the content.
+>
+> Use alerts only when they are crucial for user success and limit them to one or two per article to prevent overloading the reader. Additionally, you should avoid placing alerts consecutively. Alerts cannot be nested within other elements.
+>
+> To add an alert, use a special blockquote line specifying the alert type, followed by the alert information in a standard blockquote. Five types of alerts are available: ...
+
+Just the Docs has now implemented the same kinds of alerts as GitHub, and renders them with similar styling.
+You can also use a further kind, called `ALERT`, intended for alerts whose content doesn't match the predefined kinds (`ALERT` treats the first paragraph of the alert content as the heading, and uses a neutral color).
+
+{: .NOTE }
+> Use of the predefined alerts does *not* require any configuration.
+
+You can easily [customize](#customization) the headings and colors of the predefined alerts, and add new kinds.
+
+The Just the Docs syntax for alerts is illustrated below. It uses a Markdown extension supported by Kramdown ([*block IALs*](https://kramdown.gettalong.org/quickref.html#block-attributes)) together with the usual blockquote syntax.[^GFM]
+You should put the block IAL on a line by itself directly before (or directly after) the alert content, and separate the block IAL from other content by a blank line.
+
+[^GFM]: The Kramdown parser for GFM (GitHub-Flavored Markdown) does not recognize the GitHub alerts syntax.
+
+You can use the following button to see the colors used for the predefined alerts with the `dark` color scheme. (The accessibility of the colors has not yet been reviewed.)
+
+<button class="btn js-toggle-dark-mode">Preview dark color scheme</button>
+
+<script>
+const toggleDarkMode = document.querySelector('.js-toggle-dark-mode');
+
+jtd.addEvent(toggleDarkMode, 'click', function(){
+  if (jtd.getTheme() === 'dark') {
+    jtd.setTheme('light');
+    toggleDarkMode.textContent = 'Preview dark color scheme';
+  } else {
+    jtd.setTheme('dark');
+    toggleDarkMode.textContent = 'Return to the light side';
+  }
+});
+</script>
+
+## Single-paragraph alerts
+
+{: .lh-0 }
+```markdown
+{: .NOTE }
+> Useful information that users should know, even when skimming content.
+
+{: .TIP }
+> Helpful advice for doing things better or more easily.
+
+{: .IMPORTANT }
+> Key information users need to know to achieve their goal.
+
+{: .WARNING }
+> Urgent info that needs immediate user attention to avoid problems.
+
+{: .CAUTION }
+> Advises about risks or negative outcomes of certain actions.
+
+{: .ALERT }
+> v0.10.x
+>
+> Alerts are a new feature of Just the Docs
+```
+
+(The ASCII symbols currently displayed in the predefined alerts are to be replaced by SVG icons.)
+
+{: .NOTE }
+> Useful information that users should know, even when skimming content.
+
+{: .TIP }
+> Helpful advice for doing things better or more easily.
+
+{: .IMPORTANT }
+> Key information users need to know to achieve their goal.
+
+{: .WARNING }
+> Urgent info that needs immediate user attention to avoid problems.
+
+{: .CAUTION }
+> Advises about risks or negative outcomes of certain actions.
+
+{: .ALERT }
+> v0.10.x
+>
+> Alerts are a new feature of Just the Docs
+
+For compatibility with the syntax for callouts, a single paragaph doesn't need to be enclosed in a blockquote:
+
+{: .lh-0 }
+```markdown
+{: .NOTE }
+Useful information that users should know, even when skimming content.
+```
+
+{: .NOTE }
+Useful information that users should know, even when skimming content.
+
+
+## An alert with no content
+
+{: .lh-0 }
+```markdown
+{: .NOTE }
+>
+```
+
+{: .NOTE }
+>
+
+## Multi-paragraph alerts
+
+{: .lh-0 }
+```markdown
+{: .TIP }
+> A paragraph
+>
+> Another paragraph
+>
+> The last paragraph
+
+*Some ordinary paragraphs...*
+
+{: .ALERT }
+> The alert heading
+>
+> The first content paragraph
+>
+> The last content paragraph
+```
+
+{: .TIP }
+> A paragraph
+>
+> Another paragraph
+>
+> The last paragraph
+
+*Some ordinary paragraphs...*
+
+{: .ALERT }
+> The alert heading
+>
+> The first content paragraph
+>
+> The last content paragraph
+
+## Nested alerts
+
+{: .lh-0 }
+```markdown
+{: .IMPORTANT }
+> You can nest alerts!
+>
+> {: .CAUTION }
+> > Nesting might cause confusion
+```
+
+{: .IMPORTANT }
+> You can nest alerts!
+>
+> {: .CAUTION }
+> > Nesting might cause confusion
+
+## Customization
+
+You can easily customize the headings and colors of the predefined alerts, and add new kinds of alerts. For example, add the following SCSS to the file `_sass/custom/custom.scss` to define several shades of a `pink` color, and call the `alert` mixin with a shade of pink that gives acceptable contrast with the current color-scheme: 
+
+{: .lh-0 }
+```scss
+$pink-000: #f77ef1;
+$pink-100: #f967f1;
+$pink-200: #e94ee1;
+$pink-300: #dd2cd4;
+
+$a-new-color: $pink-200; // default/light color-scheme
+
+@if $color-scheme == dark {
+  $a-new-color: $pink-000;
+}
+
+@include alert(NEW, $a-new-color, "🆕");
+```
+
+You can use any valid HTML classname as the name of the alert. Classnames are case-sensitive, and all classnames used internally by Just the Docs are lowercase; using uppercase classnames for alerts helps to avoid clashes between style rules.
+
+Note that you can choose the alert colors for each color scheme independently.
+
+{: .lh-0 }
+```markdown
+{: .NEW }
+> This is how a new alert might look
+```
+
+{: .NEW }
+> This is how a new alert might look
+
+If you replace `NEW` above by one of the predefined alert names, the predefined alert is overridden.
+
+----

--- a/docs/ui-components/callouts.md
+++ b/docs/ui-components/callouts.md
@@ -1,7 +1,7 @@
 ---
 title: Callouts
 parent: UI Components
-nav_order: 7
+nav_order: 8
 ---
 
 # Callouts
@@ -17,10 +17,30 @@ Common kinds of callouts include `highlight`, `important`, `new`, `note`, and `w
 {: .warning }
 These callout names are *not* pre-defined by the theme: you need to define your own names.
 
-When you have [configured]({% link docs/configuration.md %}#callouts) the  `color` and (optional) `title` for a callout, you can apply it to a paragraph, or to a block quote with several paragraphs, as illustrated below.[^postfix]
+When you have [configured]({% link docs/configuration.md %}#callouts) the `color` and (optional) `title` for a callout, you can apply it to a paragraph, or to a block quote with several paragraphs, as illustrated below.[^postfix]
+(There is no blank line between the callout markup and its content, but the markup needs to be separated from other paragraphs by blank lines.)
 
 [^postfix]:
     You can put the callout markup either before or after its content.
+
+You can use the following button to see how the callout colors used on this page appear with the `dark` color scheme.
+The colors used for the predefined alerts generally have better contrast than the callout colors.
+
+<button class="btn js-toggle-dark-mode">Preview dark color scheme</button>
+
+<script>
+const toggleDarkMode = document.querySelector('.js-toggle-dark-mode');
+
+jtd.addEvent(toggleDarkMode, 'click', function(){
+  if (jtd.getTheme() === 'dark') {
+    jtd.setTheme('light');
+    toggleDarkMode.textContent = 'Preview dark color scheme';
+  } else {
+    jtd.setTheme('dark');
+    toggleDarkMode.textContent = 'Return to the light side';
+  }
+});
+</script>
 
 ## An untitled callout
 {: .no_toc .text-delta }


### PR DESCRIPTION
This PR adds alerts as an alternative to callouts. See also https://github.com/just-the-docs/just-the-docs/issues/1600#issuecomment-2611484915.

The kinds and rendering of the predefined alerts are similar to the alerts supported on GitHub. However, the colors and headings can be customized, and further kinds of alerts can be added.

See the new [docs page for Alerts in the preview](https://deploy-preview-1602--just-the-docs.netlify.app/docs/ui-components/alerts/#alerts) for further details.