### PR TITLE
Add rel=edit attribute to "Edit this page on GitHub" link

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -25,7 +25,7 @@
           site.gh_edit_view_mode
         %}
           <p class="text-small text-grey-dk-000 mb-0">
-            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
+            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page" rel="edit">{{ site.gh_edit_link_text }}</a>
           </p>
         {% endif %}
       </div>


### PR DESCRIPTION
This PR adds the `rel="edit"` attribute to the "Edit this page on GitHub" edit link.

rel=edit lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website.