### PR TITLE
Initial implementation of web worker for lunr indexing

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -170,9 +170,6 @@ function initSearch() {
   request.send();
 }
 
-function buildSearchIndex(docs) {
-}
-
 function searchLoaded(index, docs) {
   var index = index;
   var docs = docs;


### PR DESCRIPTION
This is a first attempt at using a web worker thread to perform the indexing for lunr, so the page remains responsive while the index is being built. The code also includes a synchronous fallback for situations where the web worker API is not available, though I am not sure this is actually relevant for existing browsers. After a few seconds, there is still a brief freeze in screen refresh as the index is loaded, but at least the page is usually able to finish its initial layout pass.

This fix is currently being used by our experimental documentation site at https://mgroeber9110.github.io/just-the-docs-test.

I have not done much frontend development in the last 15 years or so, so any feedback is welcome. :-)

Closes  #1210.