### PR TITLE
Use Ruby regex for excluding images to fix packaging on Windows

### DIFF
--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => "https://github.com/just-the-docs/just-the-docs",
   }
 
-  spec.files         = `git ls-files -z ':!:*.jpg' ':!:*.png'`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README|CHANGELOG|favicon)}i) && !f.match(/\.(jpg|png)$/i)}
   spec.executables   << 'just-the-docs'
 
   spec.add_development_dependency "bundler", ">= 2.3.5"


### PR DESCRIPTION
This is a small change for the command that collects the files for the Gem: I found that command line persing in Windows differs in the conventions for argument quoting, so the `':!:*.jpg'` exclude pattern for `git ls-files` does not work as expected. This prevents packaging the Gem on Windows (including things that would be useful during development, such as directly referencing the path of the JTD repository in the Gemfile of my local site for testing).

I have tried to work around this by using Ruby for defining exclusion patterns instead.