### PR TITLE
Reduce top and bottom <hr> margin in print styles

### DIFF
--- a/_sass/print.scss
+++ b/_sass/print.scss
@@ -10,6 +10,11 @@
     display: none !important;
   }
 
+  hr {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
   .side-bar {
     width: 100%;
     height: auto;


### PR DESCRIPTION
When printing a page there is a large amount of whitespace around `<hr>` elements which – although fine on-screen – appears excessive on the page. This halves the top and bottom margin on the element when printing.