### PR TITLE
Change aria-pressed into aria-expanded for buttons connected to expandable content

### DIFF
--- a/_includes/components/nav/links.html
+++ b/_includes/components/nav/links.html
@@ -13,7 +13,7 @@
   {%- if include.all == true or node.nav_exclude != true -%}
 
   {%- if include.ancestors contains node.title -%}
-  
+
     <li class="nav-list-item">
       <a href="{{ node.url | relative_url }}" class="nav-list-link"> ∞ </a>
     </li>
@@ -26,12 +26,12 @@
     {%- endcapture -%}
 
   {%- else -%}
-  
+
     {%- include components/nav/children.html node=node ancestors=include.ancestors all=include.all -%}
 
     <li class="nav-list-item">
       {%- if nav_children.size >= 1 -%}
-      <button class="nav-list-expander btn-reset" aria-label="toggle items in {{ node.title }} category" aria-pressed="false">
+      <button class="nav-list-expander btn-reset" aria-label="toggle items in {{ node.title }} category" aria-expanded="false">
         <svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#svg-arrow-right"></use></svg>
       </button>
       {%- endif -%}
@@ -44,9 +44,9 @@
         {%- include components/nav/links.html pages=nav_children ancestors=nav_ancestors all=include.all -%}
       {%- endif -%}
     </li>
-  
+
   {%- endif -%}
-  
+
   {%- endif -%}
   {%- endfor -%}
 </ul>

--- a/_includes/components/nav/links.html
+++ b/_includes/components/nav/links.html
@@ -31,7 +31,7 @@
 
     <li class="nav-list-item">
       {%- if nav_children.size >= 1 -%}
-      <button class="nav-list-expander btn-reset" aria-label="toggle items in {{ node.title }} category" aria-expanded="false">
+      <button class="nav-list-expander btn-reset" aria-label="{{ node.title }} submenu" aria-expanded="false">
         <svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#svg-arrow-right"></use></svg>
       </button>
       {%- endif -%}

--- a/_includes/components/sidebar.html
+++ b/_includes/components/sidebar.html
@@ -12,7 +12,7 @@
 <div class="side-bar">
   <div class="site-header" role="banner">
     <a href="{{ '/' | relative_url }}" class="site-title lh-tight">{% include title.html %}</a>
-    <button id="menu-button" class="site-button btn-reset" aria-label="Toggle menu" aria-expanded="false">
+    <button id="menu-button" class="site-button btn-reset" aria-label="Menu" aria-expanded="false">
       <svg viewBox="0 0 24 24" class="icon" aria-hidden="true"><use xlink:href="#svg-menu"></use></svg>
     </button>
   </div>

--- a/_includes/components/sidebar.html
+++ b/_includes/components/sidebar.html
@@ -12,7 +12,7 @@
 <div class="side-bar">
   <div class="site-header" role="banner">
     <a href="{{ '/' | relative_url }}" class="site-title lh-tight">{% include title.html %}</a>
-    <button id="menu-button" class="site-button btn-reset" aria-label="Toggle menu" aria-pressed="false">
+    <button id="menu-button" class="site-button btn-reset" aria-label="Toggle menu" aria-expanded="false">
       <svg viewBox="0 0 24 24" class="icon" aria-hidden="true"><use xlink:href="#svg-menu"></use></svg>
     </button>
   </div>

--- a/_includes/components/site_nav.html
+++ b/_includes/components/site_nav.html
@@ -47,7 +47,7 @@
             <ul class="nav-list nav-category-list">
               <li class="nav-list-item">
                 {%- if collection.size > 0 -%}
-                <button class="nav-list-expander btn-reset" aria-label="Toggle collection {{ collection_value.name }}" aria-expanded="false">
+                <button class="nav-list-expander btn-reset" aria-label="{{ collection_value.name }} collection" aria-expanded="false">
                   <svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#svg-arrow-right"></use></svg>
                 </button>
                 {%- endif -%}

--- a/_includes/components/site_nav.html
+++ b/_includes/components/site_nav.html
@@ -47,7 +47,7 @@
             <ul class="nav-list nav-category-list">
               <li class="nav-list-item">
                 {%- if collection.size > 0 -%}
-                <button class="nav-list-expander btn-reset" aria-label="Toggle collection {{ collection_value.name }}" aria-pressed="false">
+                <button class="nav-list-expander btn-reset" aria-label="Toggle collection {{ collection_value.name }}" aria-expanded="false">
                   <svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#svg-arrow-right"></use></svg>
                 </button>
                 {%- endif -%}

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -32,7 +32,7 @@ function initNav() {
     }
     if (target) {
       e.preventDefault();
-      target.ariaPressed = target.parentNode.classList.toggle('active');
+      target.ariaExpanded = target.parentNode.classList.toggle('active');
     }
   });
 
@@ -48,11 +48,11 @@ function initNav() {
     if (menuButton.classList.toggle('nav-open')) {
       siteNav.classList.add('nav-open');
       mainHeader.classList.add('nav-open');
-      menuButton.ariaPressed = true;
+      menuButton.ariaExpanded = true;
     } else {
       siteNav.classList.remove('nav-open');
       mainHeader.classList.remove('nav-open');
-      menuButton.ariaPressed = false;
+      menuButton.ariaExpanded = false;
     }
   });
 


### PR DESCRIPTION
This PR changes `aria-pressed` to `aria-expanded` on buttons toggling expandable content.

`aria-pressed` is used for e.g. switch buttons, a screen reader will announce "on" or "off" with the button. [MDN on aria-pressed](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-pressed).

For expandable content like menus the correct attribute is `aria-expanded`. The screen reader will announce the accessible name (the aria-label in this case) of the button adding the state expanded or collapsed when the button gets focus. [MDN on aria-expanded](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded).

This PR also simplifies aria-label for buttons with `aria-expanded`: when `aria-expanded` is used there is no need to add to the aria-label the text “toggle", because the `aria-expanded` already gives that info plus the state of the toggle.

So: “Menu”, instead of “Toggle menu”.
The screen reader will announce the info as:
> Button Menu collapsed

and

> Button Menu expanded

Also it is for voice recognition software advisable to start the aria-label with the text a user may guess what the button stands for, to focus it. 