### PR TITLE
Replace CSS `rgba()` function calls with `rgb()`

### DIFF
--- a/_includes/css/callouts.scss.liquid
+++ b/_includes/css/callouts.scss.liquid
@@ -23,7 +23,7 @@ p.{{ callout[0] }}, blockquote.{{ callout[0] }} {
     background: rgba(${{ callout[1].color }}-{{ callout_background_hue }}, {{ callout_opacity }});
     border-left: $border-radius solid ${{ callout[1].color }}-{{ callout_color_hue }};
     border-radius: $border-radius;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 2px rgb(0, 0, 0, 0.12), 0 3px 10px rgb(0, 0, 0, 0.08);
     padding: .8rem;
     {% if callout[1].title %}
     &::before {
@@ -47,10 +47,10 @@ p.{{ callout[0] }}, blockquote.{{ callout[0] }} {
 }
 
 p.{{ callout[0] }}-title, blockquote.{{ callout[0] }}-title {
-    background: rgba(${{ callout[1].color }}-{{ callout_background_hue }}, {{ callout_opacity }});
+    background: rgb(${{ callout[1].color }}-{{ callout_background_hue }}, {{ callout_opacity }});
     border-left: $border-radius solid ${{ callout[1].color }}-{{ callout_color_hue }};
     border-radius: $border-radius;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 2px rgb(0, 0, 0, 0.12), 0 3px 10px rgb(0, 0, 0, 0.08);
     padding: .8rem;
     > p:first-child {
       margin-top: 0;
@@ -67,11 +67,11 @@ p.{{ callout[0] }}-title, blockquote.{{ callout[0] }}-title {
 blockquote.{{ callout[0] }} {
   margin-left: 0;
   margin-right: 0;
-  
+
   > p:first-child {
     margin-top: 0;
   }
-    
+
   > p:last-child {
     margin-bottom: 0;
   }
@@ -80,11 +80,11 @@ blockquote.{{ callout[0] }} {
 blockquote.{{ callout[0] }}-title {
   margin-left: 0;
   margin-right: 0;
-  
+
   > p:nth-child(2) {
     margin-top: 0;
   }
-    
+
   > p:last-child {
     margin-bottom: 0;
   }

--- a/_sass/buttons.scss
+++ b/_sass/buttons.scss
@@ -18,19 +18,19 @@
   border-width: 0;
   border-radius: $border-radius;
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.12),
-    0 3px 10px rgba(0, 0, 0, 0.08);
+    0 1px 2px rgb(0, 0, 0, 0.12),
+    0 3px 10px rgb(0, 0, 0, 0.08);
   appearance: none;
 
   &:focus {
     text-decoration: none;
     outline: none;
-    box-shadow: 0 0 0 3px rgba(blue, 0.25);
+    box-shadow: 0 0 0 3px rgb(blue, 0.25);
   }
 
   &:focus:hover,
   &.selected:focus {
-    box-shadow: 0 0 0 3px rgba(blue, 0.25);
+    box-shadow: 0 0 0 3px rgb(blue, 0.25);
   }
 
   &:hover,
@@ -51,7 +51,7 @@
   &.zeroclipboard-is-active {
     background-color: darken($base-button-color, 3%);
     background-image: none;
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+    box-shadow: inset 0 2px 4px rgb(0, 0, 0, 0.15);
   }
 
   &.selected:hover {
@@ -62,9 +62,9 @@
   &.disabled {
     &,
     &:hover {
-      color: rgba(102, 102, 102, 0.5);
+      color: rgb(102, 102, 102, 0.5);
       cursor: default;
-      background-color: rgba(229, 229, 229, 0.5);
+      background-color: rgb(229, 229, 229, 0.5);
       background-image: none;
       box-shadow: none;
     }
@@ -91,7 +91,7 @@
     outline: none;
     box-shadow:
       inset 0 0 0 2px $grey-dk-100,
-      0 0 0 3px rgba(blue, 0.25);
+      0 0 0 3px rgb(blue, 0.25);
   }
 
   &:focus:hover,

--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -24,8 +24,8 @@
   overflow: hidden;
   border-radius: $border-radius;
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.12),
-    0 3px 10px rgba(0, 0, 0, 0.08);
+    0 1px 2px rgb(0, 0, 0, 0.12),
+    0 3px 10px rgb(0, 0, 0, 0.08);
   transition: height linear #{$transition-duration * 0.5};
 
   @include mq(md) {
@@ -99,8 +99,8 @@
   border-bottom-right-radius: $border-radius;
   border-bottom-left-radius: $border-radius;
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.12),
-    0 3px 10px rgba(0, 0, 0, 0.08);
+    0 1px 2px rgb(0, 0, 0, 0.12),
+    0 3px 10px rgb(0, 0, 0, 0.08);
 
   @include mq(md) {
     top: 100%;
@@ -232,11 +232,11 @@
   width: $sp-9;
   height: $sp-9;
   background-color: $search-background-color;
-  border: 1px solid rgba($link-color, 0.3);
+  border: 1px solid rgb($link-color, 0.3);
   border-radius: #{$sp-9 * 0.5};
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.12),
-    0 3px 10px rgba(0, 0, 0, 0.08);
+    0 1px 2px rgb(0, 0, 0, 0.12),
+    0 3px 10px rgb(0, 0, 0, 0.08);
   align-items: center;
   justify-content: center;
 }
@@ -248,7 +248,7 @@
   z-index: 1;
   width: 0;
   height: 0;
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgb(0, 0, 0, 0.3);
   opacity: 0;
   transition:
     opacity ease $transition-duration,
@@ -273,8 +273,8 @@
     @include mq(md) {
       width: $search-results-width;
       box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 3px 10px rgba(0, 0, 0, 0.08);
+        0 1px 2px rgb(0, 0, 0, 0.12),
+        0 3px 10px rgb(0, 0, 0, 0.08);
     }
   }
 

--- a/_sass/support/mixins/_buttons.scss
+++ b/_sass/support/mixins/_buttons.scss
@@ -5,8 +5,8 @@
   background-color: darken($bg, 2%);
   background-image: linear-gradient(lighten($bg, 5%), darken($bg, 2%));
   box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.25),
-    0 4px 10px rgba(0, 0, 0, 0.12);
+    0 1px 3px rgb(0, 0, 0, 0.25),
+    0 4px 10px rgb(0, 0, 0, 0.12);
 
   &:hover,
   &.zeroclipboard-is-hover {
@@ -20,7 +20,7 @@
   &.zeroclipboard-is-active {
     background-color: darken($bg, 5%);
     background-image: none;
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+    box-shadow: inset 0 2px 4px rgb(0, 0, 0, 0.15);
   }
 
   &.selected:hover {

--- a/_sass/tables.scss
+++ b/_sass/tables.scss
@@ -9,8 +9,8 @@
   overflow-x: auto;
   border-radius: $border-radius;
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.12),
-    0 3px 10px rgba(0, 0, 0, 0.08);
+    0 1px 2px rgb(0, 0, 0, 0.12),
+    0 3px 10px rgb(0, 0, 0, 0.08);
 }
 
 table {
@@ -24,7 +24,7 @@ td {
   min-width: 7.5rem;
   padding: $sp-2 $sp-3;
   background-color: $table-background-color;
-  border-bottom: $border rgba($border-color, 0.5);
+  border-bottom: $border rgb($border-color, 0.5);
   border-left: $border $border-color;
 
   @include fs-3;


### PR DESCRIPTION
This is a simple PR that find-and-replaces `rgba()` CSS calls with `rgb()`. This was first spotted in #1658 with a Stylelint bump that introduces [color-function-alias-notation](https://stylelint.io/user-guide/rules/color-function-alias-notation/).

Note this excerpt from the [MDN rgb() spec ref](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb):

> Note: The rgba() functional notation is an alias for rgb(). They are exactly equivalent. It is recommended to use rgb().

Also, observe that [5.1 of the CSS Color Module Level 4 spec](https://www.w3.org/TR/css-color-4/#rgb-functions) indicate that they have identical parsing and behaviour, other than the `rgb`/`rgba`.

---

Note: there are many cases where we see something like `rgba($feedback-color, 1)`

```
.site-nav ul li a {
  background-image: linear-gradient(
    -90deg,
    rgba($feedback-color, 1) 0%,
    rgba($feedback-color, 0.8) 80%,
    rgba($feedback-color, 0) 100%
  );
}
```

This is *not* the CSS `rgba` call, but a call to the (confusingly-named) [SASS rgba function](https://sass-lang.com/documentation/modules/#rgb). This ambiguity makes this a tricky PR!