### PR TITLE
Fix `.site-footer` color contrast

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -206,7 +206,6 @@ body {
   left: 0;
   padding-top: $sp-4;
   padding-bottom: $sp-4;
-  color: $grey-dk-000;
 
   @include container;
 


### PR DESCRIPTION
This has always bothered me as one of the only straightforward WCAG violations that we have. This should resolve it on both light & dark color schemes. No migration steps needed, and folks who have already overridden this (either by removing it and/or changing the color) are unaffected.