### PR TITLE
Fix callout body text color contrast (by removing colored backgrounds)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -160,7 +160,8 @@ gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into t
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define
 color_scheme: nil
 
-callouts_level: quiet # or loud
+# When commented out, callouts_level defaults to quiet for the light scheme, and loud for dark
+# callouts_level: quiet # or loud
 callouts:
   highlight:
     color: yellow

--- a/_includes/css/callouts.scss.liquid
+++ b/_includes/css/callouts.scss.liquid
@@ -8,7 +8,7 @@
 {%- assign callout_color_hue = "300" -%}
 {%- if site.callouts_level == "loud" or include.color_scheme == "dark" and site.callouts_level != "quiet" -%}
   {%- assign callout_background_hue = "300" -%}
-  {%- assign callout_color_hue = "000" -%}
+  {%- assign callout_color_hue = "300" -%}
 {%- endif -%}
 
 div.opaque {
@@ -17,10 +17,8 @@ div.opaque {
 
 {%- for callout in site.callouts %}
 
-{%- assign callout_opacity = callout[1].opacity | default: site.callouts_opacity | default: 0.2 -%}
-
 p.{{ callout[0] }}, blockquote.{{ callout[0] }} {
-    background: rgba(${{ callout[1].color }}-{{ callout_background_hue }}, {{ callout_opacity }});
+    border: 1px ${{ callout[1].color }}-{{ callout_background_hue }} solid;
     border-left: $border-radius solid ${{ callout[1].color }}-{{ callout_color_hue }};
     border-radius: $border-radius;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
@@ -47,7 +45,7 @@ p.{{ callout[0] }}, blockquote.{{ callout[0] }} {
 }
 
 p.{{ callout[0] }}-title, blockquote.{{ callout[0] }}-title {
-    background: rgba(${{ callout[1].color }}-{{ callout_background_hue }}, {{ callout_opacity }});
+    border: 1px ${{ callout[1].color }}-{{ callout_background_hue }} solid;
     border-left: $border-radius solid ${{ callout[1].color }}-{{ callout_color_hue }};
     border-radius: $border-radius;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
@@ -67,11 +65,11 @@ p.{{ callout[0] }}-title, blockquote.{{ callout[0] }}-title {
 blockquote.{{ callout[0] }} {
   margin-left: 0;
   margin-right: 0;
-  
+
   > p:first-child {
     margin-top: 0;
   }
-    
+
   > p:last-child {
     margin-bottom: 0;
   }
@@ -80,11 +78,11 @@ blockquote.{{ callout[0] }} {
 blockquote.{{ callout[0] }}-title {
   margin-left: 0;
   margin-right: 0;
-  
+
   > p:nth-child(2) {
     margin-top: 0;
   }
-    
+
   > p:last-child {
     margin-bottom: 0;
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,8 +186,8 @@ See [Customization]({% link docs/customization.md %}) for more information.
 ## Callouts
 {: .d-inline-block }
 
-New (v0.4.0)
-{: .label .label-green }
+Updated (v0.11.0)
+{: .label .label-yellow }
 
 To use this feature, you need to configure a `color` and (optionally) `title` for each kind of callout you want to use, e.g.:
 
@@ -198,47 +198,29 @@ callouts:
     color: red
 ```
 
-This uses the color `$red-000` for the background of the callout, and `$red-300` for the title and box decoration.[^dark] You can then style a paragraph as a `warning` callout like this:
+This uses the color `$red-300` for the title and left border, and `$red-000` for the other borders. You can then style a paragraph as a `warning` callout like this:
 
 ```markdown
 {: .warning }
 A paragraph...
 ```
 
-[^dark]:
-    If you use the `dark` color scheme, this callout uses `$red-300` for the background, and `$red-000` for the title.
+{: .warning }
+A paragraph...
 
 The colors `grey-lt`, `grey-dk`, `purple`, `blue`, `green`, `yellow`, and `red` are predefined; to use a custom color, you need to define its `000` and `300` levels in your SCSS files. For example, to use `pink`, add the following to your `_sass/custom/setup.scss` file:
 
 ```scss
 $pink-000: #f77ef1;
-$pink-100: #f967f1;
-$pink-200: #e94ee1;
 $pink-300: #dd2cd4;
 ```
 
-You can override the default `opacity` of the background for a particular callout, e.g.:
+You can also adjust the overall level of callouts. Both color schemes use `300` color level for the title and left border. The difference is for the rest of the border:
 
-```yaml
-callouts:
-  custom:
-    color: pink
-    opacity: 0.3
-```
+- `quiet` (the default when using the `light` or custom color schemes) uses `-000` as the outline
+- `loud` (the default when using the `dark` color scheme) uses `-300` as the outline
 
-You can change the default opacity (`0.2`) for all callouts, e.g.:
-
-```yaml
-callouts_opacity: 0.3
-```
-
-You can also adjust the overall level of callouts.
-The value of `callouts_level` is either `quiet` or `loud`;
-`loud` increases the saturation and lightness of the backgrounds.
-The default level is `quiet` when using the `light` or custom color schemes,
-and `loud` when using the `dark color scheme.`
-
-See [Callouts]({% link docs/ui-components/callouts.md %}) for more information.
+See [Callouts]({% link docs/ui-components/callouts.md %}) for more information. The colors used in the theme are further described in [Color Utilities]({% link docs/utilities/color.md %}).
 
 ## Google Analytics
 

--- a/docs/ui-components/callouts.md
+++ b/docs/ui-components/callouts.md
@@ -22,6 +22,26 @@ When you have [configured]({% link docs/configuration.md %}#callouts) the  `colo
 [^postfix]:
     You can put the callout markup either before or after its content.
 
+The following examples were generated with this configuration:
+
+```yml
+callouts:
+  highlight:
+    color: yellow
+  important:
+    title: Important
+    color: blue
+  new:
+    title: New
+    color: green
+  note:
+    title: Note
+    color: purple
+  warning:
+    title: Warning
+    color: red
+```
+
 ## An untitled callout
 {: .no_toc .text-delta }
 


### PR DESCRIPTION
This PR slightly reimagines callouts to fix longstanding accessibility issues (on the light theme). By removing the `background-color` from them, body text for the callout now will always have sufficient background contrast (as the background is the same as the overall theme). This includes cases where users use other styles that modify text color, such as links or `code` snippets.

As opacity is now no longer relevant, that option has been removed. Users who have it enabled will see no difference, so this is not breaking in *that* sense.

Separately, I've changed "loud" to not use any of the lighter colors, which is necessary to achieve proper contrast in light mode. I'll revisit dark mode later (see below).

--

Note that this PR does not fix these *other* issues with callouts:

- in the dark theme, the provided colors do not contrast sufficiently with the black background, which particularly affects callout titles. I will likely fix this in a dark theme pass, rather than in this PR. (I will most likely pick a different color palette for the dark theme, but will need to ponder)
- separately, callouts can "inherit" other issues with the dark theme, e.g. the link color not contrasting sufficiently. I'll resolve this separately as well.

--

I'll include a note in the migration docs on how to revert this change, as I understand that some users like having the background color. But, my hope is in the long-term to instead merge in @pdmosses work in #1602 and then keep this callout feature in maintenance mode.