### PR TITLE
Fix button and label color contrast

### DIFF
--- a/_sass/buttons.scss
+++ b/_sass/buttons.scss
@@ -109,11 +109,11 @@
 }
 
 .btn-blue {
-  @include btn-color($white, $blue-000);
+  @include btn-color($white, $blue-200);
 }
 
 .btn-green {
-  @include btn-color($white, $green-100);
+  @include btn-color($white, $green-300);
 }
 
 .btn-reset {

--- a/_sass/labels.scss
+++ b/_sass/labels.scss
@@ -20,7 +20,7 @@
 }
 
 .label-green:not(g) {
-  background-color: $green-200;
+  background-color: $green-300;
 }
 
 .label-purple:not(g) {
@@ -28,7 +28,7 @@
 }
 
 .label-red:not(g) {
-  background-color: $red-200;
+  background-color: $red-300;
 }
 
 .label-yellow:not(g) {


### PR DESCRIPTION
Pretty self-explanatory. Don't love the new visual language, but this is the best way to stay consistent within JtD's design language.

Note that this applies to both light and dark schemes, *but* separately the dark link buttons (without colored backgrounds) rely on the link color, which needs to be fixed.