### PR TITLE
Fix `.site-footer` focus order on `sm` viewport (mobile)

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -1,34 +1,49 @@
 {% capture footer_custom %}
   {%- include footer_custom.html -%}
 {% endcapture %}
-{% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link or site.back_to_top %}
-  <hr>
-  <footer>
-    {% if site.back_to_top %}
-      <p><a href="#top" id="back-to-top">{{ site.back_to_top_text }}</a></p>
-    {% endif %}
+<hr>
+<footer>
+  {% if site.back_to_top %}
+    <p><a href="#top" id="back-to-top">{{ site.back_to_top_text }}</a></p>
+  {% endif %}
 
-    {{ footer_custom }}
+  {{ footer_custom }}
 
-    {% if site.last_edit_timestamp or site.gh_edit_link %}
-      <div class="d-flex mt-2">
-        {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
-          <p class="text-small text-grey-dk-000 mb-0 mr-2">
-            Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
-          </p>
-        {% endif %}
-        {% if
-          site.gh_edit_link and
-          site.gh_edit_link_text and
-          site.gh_edit_repository and
-          site.gh_edit_branch and
-          site.gh_edit_view_mode
-        %}
-          <p class="text-small text-grey-dk-000 mb-0">
-            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
-          </p>
-        {% endif %}
+  {% if site.last_edit_timestamp or site.gh_edit_link %}
+    <div class="d-flex mt-2">
+      {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
+        <p class="text-small text-grey-dk-000 mb-0 mr-2">
+          Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
+        </p>
+      {% endif %}
+      {% if
+        site.gh_edit_link and
+        site.gh_edit_link_text and
+        site.gh_edit_repository and
+        site.gh_edit_branch and
+        site.gh_edit_view_mode
+      %}
+        <p class="text-small text-grey-dk-000 mb-0">
+          <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
+        </p>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {%- comment -%}
+    note: nav_footer_custom and/or this "site footer" appear in components/sidebar.html for the desktop view.
+  {%- endcomment -%}
+
+  <div class="d-sm-block d-md-none">
+    {% capture nav_footer_custom %}
+      {%- include nav_footer_custom.html -%}
+    {% endcapture %}
+    {% if nav_footer_custom != "" %}
+      {{ nav_footer_custom }}
+    {% else %}
+      <div class="mt-4 fs-2">
+        This site uses <a href="https://github.com/just-the-docs/just-the-docs">Just the Docs</a>, a documentation theme for Jekyll.
       </div>
     {% endif %}
-  </footer>
-{% endif %}
+  </div>
+</footer>

--- a/_includes/components/sidebar.html
+++ b/_includes/components/sidebar.html
@@ -19,14 +19,20 @@
 
   {% include_cached components/site_nav.html %}
 
+  {%- comment -%}
+    note: nav_footer_custom and/or this "site footer" appear in components/footer.html for the mobile view.
+  {%- endcomment -%}
+
+  <div class="d-md-block d-sm-none">
   {% capture nav_footer_custom %}
     {%- include nav_footer_custom.html -%}
   {% endcapture %}
   {% if nav_footer_custom != "" %}
     {{ nav_footer_custom }}
   {% else %}
-    <footer class="site-footer">
+    <div class="site-footer">
       This site uses <a href="https://github.com/just-the-docs/just-the-docs">Just the Docs</a>, a documentation theme for Jekyll.
-    </footer>
+    </div>
   {% endif %}
+  </div>
 </div>

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -185,21 +185,6 @@
   );
 }
 
-// stylelint-disable selector-max-type
-
-body {
-  position: relative;
-  padding-bottom: $sp-10;
-  overflow-y: scroll;
-
-  @include mq(md) {
-    position: static;
-    padding-bottom: 0;
-  }
-}
-
-// stylelint-enable selector-max-type
-
 .site-footer {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
This PR moves the mobile `.site-footer` (by default, "This site uses Just the Docs...") to the `footer.html` includes component, instead of staying in the sidebar. This means that the structure of the markup now properly manages the visual order, which then fixes the tab order issue identified in #1667.

This has two side effects:
- the spacing of the `.site-footer` is better (imo!)
- this now causes a slight behavioural change if the user has no other footer content, *and* wants an empty `.site-footer` - this will now cause an empty `<footer>` with an extra `<hr>`. This does cause a difference, but I think this is an acceptable compromise, especially as I think this is relatively uncommon (and a user who really wanted this should just completely override `footer.html`)

Closes #1667.