### PR TITLE
Fix color contrast between dark mode background and `$link-color`

### DIFF
--- a/_sass/color_schemes/dark.scss
+++ b/_sass/color_schemes/dark.scss
@@ -2,7 +2,7 @@ $color-scheme: dark;
 $body-background-color: $grey-dk-300;
 $body-heading-color: $grey-lt-000;
 $body-text-color: $grey-lt-300;
-$link-color: $blue-000;
+$link-color: lighten($blue-000, 10%);
 $nav-child-link-color: $grey-dk-000;
 $sidebar-color: $grey-dk-300;
 $base-button-color: $grey-dk-250;


### PR DESCRIPTION
None of the colors in the `blue` palette are light enough/high contrast enough. This is my best approach while keeping something that is still somewhat within the design language of this theme.

In the next-next release (automatic theme switching?) I should take a step back and think more about our color system - realistically, I need to pick smarter colors that contrast with both white and black, or pick a different set of colors.