### PR TITLE
Fixes color contrast for selected `.nav-list-link` (light mode)

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -56,6 +56,7 @@
 
       &:hover,
       &.active {
+        color: darken($link-color, 5%);
         background-image: linear-gradient(
           -90deg,
           rgba($feedback-color, 1) 0%,


### PR DESCRIPTION
Another "cheap" use of `darken` to stick with our color palette for now (changing the background shadow is much harder, as 3% is already quite light). This plays well with the new dark mode blue as well.