### PR TITLE
Fix sidebar ARIA role (by including navigation)

### DIFF
--- a/_includes/components/sidebar.html
+++ b/_includes/components/sidebar.html
@@ -9,8 +9,8 @@
   Should not be cached, because nav_footer_custom.html might depend on page.
 {%- endcomment -%}
 
-<div class="side-bar">
-  <div class="site-header" role="banner">
+<header class="side-bar">
+  <div class="site-header">
     <a href="{{ '/' | relative_url }}" class="site-title lh-tight">{% include title.html %}</a>
     <button id="menu-button" class="site-button btn-reset" aria-label="Menu" aria-expanded="false">
       <svg viewBox="0 0 24 24" class="icon" aria-hidden="true"><use xlink:href="#svg-menu"></use></svg>
@@ -35,4 +35,4 @@
     </div>
   {% endif %}
   </div>
-</div>
+</header>


### PR DESCRIPTION
Previously, the `role="banner"` only covered the site logo/title. However, in my view this should *also* include the global navigation (and ideally, *also* the search bar as well). Among other things, this creates a reasonable grouping expectation when tabbing through the website.

This has a nice side effect of maintaining the "all content must be within a landmark" that was briefly an issue when #1751 fixed the duplicate `<footer>` issue.

MDN ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/banner_role