### PR TITLE
Fix `footer_content`/`footer_custom` color contrast

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -12,7 +12,7 @@
   {% if site.last_edit_timestamp or site.gh_edit_link %}
     <div class="d-flex mt-2">
       {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
-        <p class="text-small text-grey-dk-000 mb-0 mr-2">
+        <p class="text-small mb-0 mr-2">
           Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
         </p>
       {% endif %}
@@ -23,7 +23,7 @@
         site.gh_edit_branch and
         site.gh_edit_view_mode
       %}
-        <p class="text-small text-grey-dk-000 mb-0">
+        <p class="text-small mb-0">
           <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
         </p>
       {% endif %}

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,3 +1,3 @@
 {%- if site.footer_content -%}
-  <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
+  <p class="text-small mb-0">{{ site.footer_content }}</p>
 {%- endif -%}


### PR DESCRIPTION
This primarily fixes the issue on dark mode, though it's also a bit tricky to read on light mode too.

In general, we shouldn't be hardcoding `text-grey` when using responsive themes like this. Probably instead need different e.g. `.text-primary`, `.text-secondary`-style classes.