### PR TITLE
Fix usage of deprecated css properties (`word-wrap`, `clip`) and values (`appearance: button`)

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -152,7 +152,7 @@
 .search-result-doc {
   display: flex;
   align-items: center;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 
   &.search-result-doc-parent {
     opacity: 0.5;
@@ -178,7 +178,7 @@
 
 .search-result-section {
   margin-left: #{$sp-4 + $sp-2};
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .search-result-rel-url {
@@ -198,7 +198,7 @@
   padding-left: $sp-4;
   margin-left: $sp-2;
   color: $search-result-preview-color;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   border-left: $border;
   border-left-color: $border-color;
   @include fs-2;

--- a/_sass/utilities/_layout.scss
+++ b/_sass/utilities/_layout.scss
@@ -31,7 +31,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border-width: 0;
 }

--- a/_sass/vendor/normalize.scss/normalize.scss
+++ b/_sass/vendor/normalize.scss/normalize.scss
@@ -198,7 +198,7 @@ button,
 [type="button"],
 [type="reset"],
 [type="submit"] {
-  appearance: button;
+  appearance: auto;
 }
 
 /**
@@ -308,7 +308,7 @@ textarea {
  */
 
 ::-webkit-file-upload-button {
-  appearance: button; /* 1 */
+  appearance: auto; /* 1 */
   font: inherit; /* 2 */
 }
 


### PR DESCRIPTION
- for `word-wrap` - see https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap
- for `clip` - see https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/clip and https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/clip-path . Fix was taken from similar note in tailwind: https://github.com/tailwindlabs/tailwindcss/issues/18768
- for `appearance` - see https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/appearance

All have full browser support from the active browserlist in MDN (going back many, many major versions).

(should we be updating normalize to something modern? not sure)