### PR TITLE
Fix incorrect main content spacing in print styles

### DIFF
--- a/_sass/print.scss
+++ b/_sass/print.scss
@@ -19,6 +19,7 @@
     width: 100%;
     height: auto;
     border-right: 0 !important;
+
     /* Disable display: flex and position: fixed from non-print styles */
     position: static;
     display: block;


### PR DESCRIPTION
This PR fixes some issues with how `.main` and `.side-bar` interact in CSS print styles (both portrait and landscape). In particular, because `.side-bar + .main` has a higher specificity than `.main` within the print media query, the `margin-left: 0` wasn't being properly applied. This PR fixes that by bumping the importance of the `margin-left` and disabling the `position: fixed` of the sidebar (which, in my view, makes sense from a page printing perspective - you likely only want the nav to show on the first page, if at all).

There's a bit more print optimization that we can do - might be worth spinning up a test flow for this. There are some particularly nasty interactions between dark mode and print styling that might affect our ability to roll out automatic theme switching - will need to think (and research) more about that.

Closes #1457.