### PR TITLE
Fix search bar focus trap and search result focus outline clipping

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -128,6 +128,7 @@
 .search-result {
   display: block;
   padding: $sp-1 $sp-3;
+  outline-offset: -1px;
 
   &:hover,
   &.active {

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -418,6 +418,25 @@ function searchLoaded(index, docs) {
     setTimeout(update, 0);
   });
 
+  // When the search bar is *not* focused, it should be hidden. This code
+  // manages that - which is a bit tricky given that we can't just rely on
+  // focusout, since we could be re-focusing within the search itself.
+  const updateSearchFocus = function(evt) {
+    const nextFocusedElement = evt.relatedTarget;
+
+    // Re-focusing on search bar - "keep focus"
+    if (nextFocusedElement.id === 'search-input') return;
+
+    // Re-focusing on the next search result element - "keep focus"
+    if (nextFocusedElement.classList.contains('search-result')) return;
+
+    // Otherwise, we're not focused on the search bar anymore. Hide!
+    hideSearch();
+  }
+
+  searchInput.addEventListener('focusout', updateSearchFocus);
+  searchResults.addEventListener('focusout', updateSearchFocus);
+
   jtd.addEvent(searchInput, 'keyup', function(e){
     switch (e.keyCode) {
       case 27: // When esc key is pressed, hide the results and clear the field


### PR DESCRIPTION
This one was a bit tricky to get right. I also think the search JS code needs some serious refactoring (that could lead to a non- trivial perf improvement), but I'm not 100% sure of that yet.

Related to #1767.