### PR TITLE
docs: fix typo in development setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Bug reports, proposals of new features, and pull requests are welcome on GitHub 
 
 ## Development
 
-To set up your environment to develop this theme: fork this repo, the run `bundle install` from the root directory.
+To set up your environment to develop this theme: fork this repo, then run `bundle install` from the root directory.
 
 Your theme is set up just like a normal Jekyll site! To test your theme, run `bundle exec jekyll serve` and open your browser at `http://localhost:4000`. This starts a Jekyll server using your theme. Add pages, documents, data, etc. like normal to test your theme's contents. As you make modifications to your theme and to your content, your site will regenerate and you should see the changes in the browser after a refresh, just like normal.
 


### PR DESCRIPTION
Fix typo in README development setup instructions.

"the run" → "then run"