### PR TITLE
feat: support path-based parent matching in navigation

### DIFF
--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -67,6 +67,10 @@
 
   {% assign nav_top_node_titles = nav_top_nodes | map: "title" -%}
 
+  {%- comment -%}
+    Pass the page to children.html, which supports both title-based and
+    path-based (parent_path) matching for i18n compatibility.
+  {%- endcomment -%}
   {%- include components/nav/children.html node=page ancestors=nav_ancestors all=true -%}
 
 {%- endunless -%}

--- a/_includes/components/nav/children.html
+++ b/_includes/components/nav/children.html
@@ -4,15 +4,57 @@
   Includes: components/nav/sorted.html.
   Assigns to: nav_children.
   Overwrites:
-    nav_candidates, nav_child, nav_child_ok.
+    nav_candidates, nav_path_candidates, nav_child, nav_child_ok.
+
+  The `parent` front matter field supports two matching modes:
+    1. Title-based (default): `parent: "Section Title"` matches parent's `title`
+    2. Path-based: `parent: "/section/"` (starts with `/`) matches parent's URL
+  Path-based matching enables i18n (translated titles), safe renames, and
+  unambiguous matching for pages with duplicate titles.
 {%- endcomment -%}
 
 {%- assign nav_children = "" | split: "" -%}
 
 {%- if include.all == true or include.node.has_children != false -%}
 
+  {%- comment -%}
+    Title-based matching (backwards compatible): find children whose
+    `parent` value matches this node's title.
+  {%- endcomment -%}
   {%- assign nav_candidates = nav_parenthood
         | where: "name", include.node.title | map: "items" | first -%}
+
+  {%- comment -%}
+    Path-based matching: find children whose `parent` starts with `/`
+    and matches this node's URL. These pages are grouped by their `parent`
+    value (e.g., "/quickstart/") in nav_parenthood, so we look up by the
+    node's URL directly, then also scan all groups for path-based parents
+    that match.
+  {%- endcomment -%}
+  {%- assign nav_node_url = include.node.url | default: include.node.permalink -%}
+  {%- assign nav_path_group = nav_parenthood
+        | where: "name", nav_node_url | map: "items" | first -%}
+  {%- assign nav_path_candidates = "" | split: "" -%}
+  {%- if nav_path_group -%}
+    {%- for nav_item in nav_path_group -%}
+      {%- assign nav_path_candidates = nav_path_candidates | push: nav_item -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {%- comment -%}
+    Merge path-based candidates into the title-based candidates,
+    avoiding duplicates.
+  {%- endcomment -%}
+  {%- if nav_candidates == nil -%}
+    {%- assign nav_candidates = nav_path_candidates -%}
+  {%- else -%}
+    {%- assign nav_existing_urls = nav_candidates | map: "url" -%}
+    {%- for nav_path_child in nav_path_candidates -%}
+      {%- unless nav_existing_urls contains nav_path_child.url -%}
+        {%- assign nav_candidates = nav_candidates | push: nav_path_child -%}
+      {%- endunless -%}
+    {%- endfor -%}
+  {%- endif -%}
 
   {%- for nav_child in nav_candidates -%}
     {%- assign nav_child_ok = true -%}
@@ -30,12 +72,16 @@
     {%- comment -%}
       The following check rejects nav_child as 3rd-level when include.node is 2nd-level
       and nav_child can also be 2nd-level. This is for backwards compatibility with
-      existing 3-level sites.
+      existing 3-level sites. Skip this check for path-based children since they
+      use explicit path matching rather than ambiguous title matching.
     {%- endcomment -%}
-    {%- if nav_child.grand_parent == nil and nav_child.ancestor == nil and 
-          nav_top_node_titles contains nav_child.parent and include.ancestors.size >= 1 -%}
-      {%- assign nav_child_ok = false -%}
-    {%- endif -%}
+    {%- assign nav_parent_first_char = nav_child.parent | slice: 0 -%}
+    {%- unless nav_parent_first_char == "/" -%}
+      {%- if nav_child.grand_parent == nil and nav_child.ancestor == nil and
+            nav_top_node_titles contains nav_child.parent and include.ancestors.size >= 1 -%}
+        {%- assign nav_child_ok = false -%}
+      {%- endif -%}
+    {%- endunless -%}
 
     {%- if nav_child_ok -%}
       {%- assign nav_children = nav_children | push: nav_child -%}


### PR DESCRIPTION
## Summary
- The `parent` front matter field now accepts a path (starting with `/`) in addition to a page title
- Path-based matching enables i18n, safe renames, and unambiguous parent-child relationships
- Fully backwards-compatible — existing sites work unchanged

## Why
The current navigation system matches children to parents by title string (`parent: "Section Title"` must exactly match the parent page's `title`). This breaks in several scenarios:

1. **i18n/multilingual docs** — Translated parent pages have different titles (`title: クイックスタート` vs `title: Quickstart`), so children with `parent: Quickstart` can't match
2. **Page renames** — Renaming a parent page requires updating every child's `parent` field
3. **Duplicate titles** — Pages with the same title in different sections cause ambiguous matching (#1708)

These are long-standing issues: #59 (Multi Language Support, 2019), #1409 (Organize pages using IDs), #1302 (auto children by path), #1570 (directory-based nav), #1708 (infinity title bug).

## How
Modified `_includes/components/nav/children.html` to support two matching modes:

```yaml
# Title-based (existing, unchanged)
parent: Quickstart

# Path-based (new)
parent: /quickstart/
```

**Detection is automatic**: if `parent` starts with `/`, match against the parent page's URL; otherwise match by title as before.

### Implementation Details
- After the existing title-based lookup, the code checks `nav_parenthood` groups for entries where the group name (the `parent` value) matches the current node's URL
- Both title-based and path-based candidates are merged, deduplicated by URL
- The backwards-compatibility check for 3-level hierarchies is skipped for path-based children (they use explicit matching, so there's no ambiguity)
- `_includes/components/children_nav.html` updated with documentation comment (no logic change — it delegates to `children.html`)

### Example: i18n Usage
```yaml
# English parent (title-based matching works)
---
title: Quickstart
permalink: /quickstart/
has_children: true
---

# Japanese child (path-based matching needed)
---
title: はじめに
parent: /quickstart/   # matches parent's URL, not title
permalink: /quickstart/getting-started/
lang: ja
---
```

## Test/Result
- Existing sites with title-based `parent` values work exactly as before
- Sites using `parent: /path/` get path-based matching that works across languages and survives title renames
- Tested with jekyll-polyglot (3 languages: EN, JA, ZH) — all sidebar navigation renders correctly with translated section titles and expanded children
- No warnings about duplicate titles or parent matching

Addresses: #59, #1302, #1409, #1570, #1708


🤖 Generated with [Claude Code](https://claude.com/claude-code)