### PR TITLE
Add `text-wrap: balance` to `.nav-list-link`

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -24,6 +24,7 @@
       padding-bottom: $sp-1;
       line-height: #{$nav-list-item-height-sm - 2 * $sp-1};
       outline-offset: -1px; // Fixes outline clipping on both desktop/mobile "views"
+      text-wrap: balance;
 
       @if $nav-list-expander-right {
         padding-right: $nav-list-item-height-sm;


### PR DESCRIPTION
This instructs [most browsers](https://caniuse.com/css-text-wrap-balance) to attempt to 'balance' the text for navigation items into similar line lengths, giving (for example):

> A long page title
> which spans two lines

instead of:

> A long page title which spans
> two lines

for a more visually pleasing sidebar.